### PR TITLE
refactor: `Observer::next` emit mut reference instead of reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [Unreleased](https://github.com/M-Adoo/rxRust/compare/v0.3.0...HEAD)
+## [Unreleased](https://github.com/M-Adoo/rxRust/compare/v0.5.0...HEAD)
+
+### Breaking Changes
+
+- **observer**: `Observer::next` emit mut reference instead of reference. 
+
+## [0.5.0](https://github.com/M-Adoo/rxRust/releases/tag/v0.5.0)  (2019-11-07)
 
 ### Features
 - **operator**: add `scan` operator.

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -172,11 +172,11 @@ mod test {
     let c_complete = complete.clone();
 
     Observable::new(|mut subscriber| {
-      subscriber.next(&1);
-      subscriber.next(&2);
-      subscriber.next(&3);
+      subscriber.next(&mut 1);
+      subscriber.next(&mut 2);
+      subscriber.next(&mut 3);
       subscriber.complete();
-      subscriber.next(&3);
+      subscriber.next(&mut 3);
       subscriber.error(&"never dispatch error");
     })
     .to_shared()
@@ -193,17 +193,17 @@ mod test {
   #[test]
   fn support_fork() {
     let o = Observable::new(|mut subscriber| {
-      subscriber.next(&1);
-      subscriber.next(&2);
-      subscriber.next(&3);
-      subscriber.next(&4);
+      subscriber.next(&mut 1);
+      subscriber.next(&mut 2);
+      subscriber.next(&mut 3);
+      subscriber.next(&mut 4);
     });
     let sum1 = Arc::new(Mutex::new(0));
     let sum2 = Arc::new(Mutex::new(0));
     let c_sum1 = sum1.clone();
     let c_sum2 = sum2.clone();
-    o.fork().subscribe(move |v| *sum1.lock().unwrap() += v);
-    o.fork().subscribe(move |v| *sum2.lock().unwrap() += v);
+    o.fork().subscribe(move |v| *sum1.lock().unwrap() += *v);
+    o.fork().subscribe(move |v| *sum2.lock().unwrap() += *v);
 
     assert_eq!(*c_sum1.lock().unwrap(), 10);
     assert_eq!(*c_sum2.lock().unwrap(), 10);
@@ -213,12 +213,12 @@ mod test {
   fn fork_and_share() {
     let observable = observable::empty();
     // shared after fork
-    observable.fork().to_shared().subscribe(|_: &()| {});
+    observable.fork().to_shared().subscribe(|_: &mut ()| {});
     observable.fork().to_shared().subscribe(|_| {});
 
     // shared before fork
     let observable = observable::empty().to_shared();
-    observable.fork().subscribe(|_: &()| {});
+    observable.fork().subscribe(|_: &mut ()| {});
     observable.fork().subscribe(|_| {});
   }
 }

--- a/src/observable/from.rs
+++ b/src/observable/from.rs
@@ -37,9 +37,9 @@ where
   Iter: IntoIterator + Clone,
 {
   Observable::new(move |mut subscriber| {
-    for v in iter.into_iter() {
+    for mut v in iter.into_iter() {
       if !subscriber.is_closed() {
-        subscriber.next(&v);
+        subscriber.next(&mut v);
       } else {
         break;
       }
@@ -68,7 +68,7 @@ where
 /// ```
 ///
 pub fn of<O, U, Item>(
-  v: Item,
+  mut v: Item,
 ) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
 where
   O: Observer<Item, ()>,
@@ -76,7 +76,7 @@ where
   Item: Clone,
 {
   Observable::new(move |mut subscriber| {
-    subscriber.next(&v);
+    subscriber.next(&mut v);
     subscriber.complete();
   })
 }
@@ -137,11 +137,11 @@ where
 /// use rxrust::prelude::*;
 ///
 /// observable::of_result(Err("An error"))
-///   .subscribe_err(|v: &i32| {}, |e| {println!("Error:  {},", e)});
+///   .subscribe_err(|v: &mut i32| {}, |e| {println!("Error:  {},", e)});
 /// ```
 ///
 pub fn of_result<O, U, Item, Err>(
-  r: Result<Item, Err>,
+  mut r: Result<Item, Err>,
 ) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
 where
   O: Observer<Item, Err>,
@@ -150,7 +150,7 @@ where
   Err: Clone,
 {
   Observable::new(move |mut subscriber| {
-    match &r {
+    match &mut r {
       Ok(v) => subscriber.next(v),
       Err(e) => subscriber.error(e),
     };
@@ -177,7 +177,7 @@ where
 /// ```
 ///
 pub fn of_option<O, U, Item>(
-  o: Option<Item>,
+  mut o: Option<Item>,
 ) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
 where
   O: Observer<Item, ()>,
@@ -185,7 +185,7 @@ where
   Item: Clone,
 {
   Observable::new(move |mut subscriber| {
-    match &o {
+    match &mut o {
       Some(v) => subscriber.next(v),
       None => (),
     };

--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -38,9 +38,9 @@ where
   F: Future + Send + Clone + Sync + 'static,
 {
   Observable::new(move |mut subscriber| {
-    let fmapped = f.map(move |v| {
+    let fmapped = f.map(move |mut v| {
       if !subscriber.is_closed() {
-        subscriber.next(&v);
+        subscriber.next(&mut v);
         subscriber.complete();
       }
     });
@@ -65,7 +65,7 @@ where
     let fmapped = f.map(move |v| {
       if !subscriber.is_closed() {
         match v.into() {
-          Ok(ref item) => {
+          Ok(ref mut item) => {
             subscriber.next(item);
             subscriber.complete();
           }

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -26,7 +26,7 @@ macro interval_observable($interval: expr) {
     let mut subscription = subscriber.subscription.clone();
     let mut number = 0;
     let f = $interval.for_each(move |_| {
-      subscriber.next(&number);
+      subscriber.next(&mut number);
       number += 1;
       future::ready(())
     });

--- a/src/observable/trivial.rs
+++ b/src/observable/trivial.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 
-/// Creates an observable that emitts no items, just terminates with an error.
+/// Creates an observable that emits no items, just terminates with an error.
 ///
 /// # Arguments
 ///
-/// * `e` - An error to emitt and terminate with
+/// * `e` - An error to emit and terminate with
 ///
 pub fn throw<O, U, Item, Err>(
   e: Err,
@@ -22,14 +22,14 @@ where
 
 /// Creates an observable that produces no values.
 ///
-/// Completes immediatelly. Never emits an error.
+/// Completes immediately. Never emits an error.
 ///
 /// # Examples
 /// ```
 /// use rxrust::prelude::*;
 ///
 /// observable::empty()
-///   .subscribe(|v: &i32| {println!("{},", v)});
+///   .subscribe(|v: &mut i32| {println!("{},", v)});
 ///
 /// // Result: no thing printed
 /// ```
@@ -72,7 +72,7 @@ mod test {
     let mut error_emitted = String::new();
     observable::throw(String::from("error")).subscribe_all(
       // helping with type inference
-      |_: &i32| value_emitted = true,
+      |_: &mut i32| value_emitted = true,
       |e: &String| error_emitted = e.to_string(),
       || completed = true,
     );

--- a/src/ops/average.rs
+++ b/src/ops/average.rs
@@ -12,7 +12,7 @@ type Accum<Item> = (Item, usize);
 /// Computing an average by multiplying accumulated nominator by a reciprocal
 /// of accumulated denominator. In this way some generic types that support
 /// linear scaling over floats values could be averaged (e.g. vectors)
-fn average_floats<T>(acc: &Accum<T>) -> T
+fn average_floats<T>(acc: &mut Accum<T>) -> T
 where
   T: Default + Copy + Send + Mul<f64, Output = T>,
 {
@@ -40,7 +40,7 @@ pub type AverageOp<Source, Item> = MapOp<
     ScanOp<Source, fn(&Accum<Item>, &Item) -> Accum<Item>, Item, Accum<Item>>,
     Accum<Item>,
   >,
-  fn(&Accum<Item>) -> Item,
+  fn(&mut Accum<Item>) -> Item,
   Accum<Item>,
 >;
 
@@ -84,7 +84,7 @@ where
     let start = (Item::default(), 0);
 
     let acc = accumulate_item as fn(&Accum<Item>, &Item) -> Accum<Item>;
-    let avg = average_floats as fn(&Accum<Item>) -> Item;
+    let avg = average_floats as fn(&mut Accum<Item>) -> Item;
 
     self.scan_initial(start, acc).last().map(avg)
   }

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -67,7 +67,7 @@ where
   S: Observer<Item, Err>,
   F: FnMut(&Item) -> bool,
 {
-  fn next(&mut self, value: &Item) {
+  fn next(&mut self, value: &mut Item) {
     if (self.filter)(value) {
       self.observer.next(value)
     }

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -28,7 +28,7 @@ where
   ///  # use rxrust::ops::FilterMap;
   ///  let mut res: Vec<i32> = vec![];
   ///   observable::from_iter(["1", "lol", "3", "NaN", "5"].iter())
-  ///   .filter_map(|s: &&&str| s.parse().ok())
+  ///   .filter_map(|s: &mut &&str| s.parse().ok())
   ///   .subscribe(|v| res.push(*v));
   ///
   /// assert_eq!(res, [1, 3, 5]);
@@ -39,7 +39,7 @@ where
     f: F,
   ) -> FilterMapOp<Self, F, SourceItem>
   where
-    F: FnMut(&SourceItem) -> Option<Item>,
+    F: FnMut(&mut SourceItem) -> Option<Item>,
   {
     FilterMapOp {
       source: self,
@@ -55,7 +55,7 @@ where
     f: F,
   ) -> FilterMapReturnRefOp<Self, F, SourceItem>
   where
-    F: FnMut(&SourceItem) -> Option<&Item>,
+    F: FnMut(&mut SourceItem) -> Option<&mut Item>,
   {
     FilterMapReturnRefOp {
       source: self,
@@ -77,7 +77,7 @@ impl<Item, Err, SourceItem, S, F, O, U>
   RawSubscribable<Item, Err, Subscriber<O, U>> for FilterMapOp<S, F, SourceItem>
 where
   S: RawSubscribable<SourceItem, Err, Subscriber<FilterMapObserver<O, F>, U>>,
-  F: FnMut(&SourceItem) -> Option<Item>,
+  F: FnMut(&mut SourceItem) -> Option<Item>,
 {
   type Unsub = S::Unsub;
   fn raw_subscribe(self, subscriber: Subscriber<O, U>) -> Self::Unsub {
@@ -144,11 +144,11 @@ impl<O, F, Item, Err, OutputItem> Observer<Item, Err>
   for FilterMapObserver<O, F>
 where
   O: Observer<OutputItem, Err>,
-  F: FnMut(&Item) -> Option<OutputItem>,
+  F: FnMut(&mut Item) -> Option<OutputItem>,
 {
-  fn next(&mut self, value: &Item) {
-    if let Some(v) = (self.f)(value) {
-      self.down_observer.next(&v)
+  fn next(&mut self, value: &mut Item) {
+    if let Some(mut v) = (self.f)(value) {
+      self.down_observer.next(&mut v)
     }
   }
   #[inline(always)]
@@ -190,7 +190,7 @@ where
     Err,
     Subscriber<FilterMapReturnRefObserver<O, F>, U>,
   >,
-  F: for<'r> FnMut(&'r SourceItem) -> Option<&'r Item>,
+  F: for<'r> FnMut(&'r mut SourceItem) -> Option<&'r mut Item>,
 {
   type Unsub = S::Unsub;
   fn raw_subscribe(self, subscriber: Subscriber<O, U>) -> Self::Unsub {
@@ -257,9 +257,9 @@ impl<O, F, Item, Err, OutputItem> Observer<Item, Err>
   for FilterMapReturnRefObserver<O, F>
 where
   O: Observer<OutputItem, Err>,
-  F: FnMut(&Item) -> Option<&OutputItem>,
+  F: FnMut(&mut Item) -> Option<&mut OutputItem>,
 {
-  fn next(&mut self, value: &Item) {
+  fn next(&mut self, value: &mut Item) {
     if let Some(v) = (self.f)(value) {
       self.down_observer.next(v)
     }

--- a/src/ops/first.rs
+++ b/src/ops/first.rs
@@ -76,15 +76,15 @@ impl<Item, Err, S> Observer<Item, Err> for FirstOrSubscribe<S, Item>
 where
   S: Observer<Item, Err>,
 {
-  fn next(&mut self, value: &Item) {
+  fn next(&mut self, value: &mut Item) {
     self.observer.next(value);
     self.default = None;
   }
   #[inline(always)]
   fn error(&mut self, err: &Err) { self.observer.error(err); }
   fn complete(&mut self) {
-    if let Some(v) = Option::take(&mut self.default) {
-      self.observer.next(&v)
+    if let Some(mut v) = Option::take(&mut self.default) {
+      self.observer.next(&mut v)
     }
     self.observer.complete();
   }

--- a/src/ops/last.rs
+++ b/src/ops/last.rs
@@ -120,15 +120,15 @@ where
   S: Observer<Item, Err>,
   Item: Clone,
 {
-  fn next(&mut self, value: &Item) { self.last = Some(value.clone()); }
+  fn next(&mut self, value: &mut Item) { self.last = Some(value.clone()); }
 
   #[inline(always)]
   fn error(&mut self, err: &Err) { self.observer.error(err); }
 
   fn complete(&mut self) {
-    let default = self.default.as_ref();
-    if let Some(v) = self.last.as_ref().or(default) {
-      self.observer.next(&v)
+    let default = self.default.as_mut();
+    if let Some(v) = self.last.as_mut().or(default) {
+      self.observer.next(v)
     }
     self.observer.complete();
   }
@@ -227,7 +227,7 @@ mod test {
     let mut last_item = None;
 
     observable::empty().last().subscribe_all(
-      |v: &i32| last_item = Some(*v),
+      |v: &mut i32| last_item = Some(*v),
       |_| errors += 1,
       || completed += 1,
     );

--- a/src/ops/minmax.rs
+++ b/src/ops/minmax.rs
@@ -16,7 +16,7 @@ pub type MinMaxOp<Source, Item> = MapOp<
     >,
     Option<Item>,
   >,
-  fn(&Option<Item>) -> Item,
+  fn(&mut Option<Item>) -> Item,
   Option<Item>,
 >;
 

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -84,12 +84,12 @@ where
   Err: Clone + Send + Sync + 'static,
   SD: Scheduler,
 {
-  fn next(&mut self, value: &Item) {
+  fn next(&mut self, value: &mut Item) {
     let s = self.scheduler.schedule(
       |subscription, state| {
         if !subscription.is_closed() {
-          let (v, observer) = state;
-          observer.lock().unwrap().next(&v);
+          let (mut v, observer) = state;
+          observer.lock().unwrap().next(&mut v);
         }
       },
       None,
@@ -144,8 +144,8 @@ mod test {
     let observe_thread = Arc::new(Mutex::new(vec![]));
     let oc = observe_thread.clone();
     Observable::new(|mut s| {
-      s.next(&1);
-      s.next(&1);
+      s.next(&mut 1);
+      s.next(&mut 1);
       *emit_thread.lock().unwrap() = thread::current().id();
     })
     .observe_on(Schedulers::NewThread)

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -274,10 +274,10 @@ fn auto_unsubscribe() {
     let ref_count = subject.fork().publish().ref_count();
     let mut s1 = ref_count.fork().subscribe(|v| accept1 = *v);
     let mut s2 = ref_count.fork().subscribe(|v| accept2 = *v);
-    subject.next(&1);
+    subject.next(&mut 1);
     s1.unsubscribe();
     s2.unsubscribe();
-    subject.next(&2);
+    subject.next(&mut 2);
   }
 
   assert_eq!(accept1, 1);

--- a/src/ops/scan.rs
+++ b/src/ops/scan.rs
@@ -138,10 +138,10 @@ where
   Source: Observer<OutputItem, Err>,
   BinaryOp: FnMut(&OutputItem, &InputItem) -> OutputItem,
 {
-  fn next(&mut self, value: &InputItem) {
+  fn next(&mut self, value: &mut InputItem) {
     // accumulating each item with a current value
     self.acc = (self.binary_op)(&self.acc, value);
-    self.target_observer.next(&self.acc)
+    self.target_observer.next(&mut self.acc)
   }
 
   #[inline(always)]

--- a/src/ops/take.rs
+++ b/src/ops/take.rs
@@ -107,7 +107,7 @@ where
   S: Observer<Item, Err>,
   ST: SubscriptionLike,
 {
-  fn next(&mut self, value: &Item) {
+  fn next(&mut self, value: &mut Item) {
     if self.hits < self.count {
       self.hits += 1;
       self.observer.next(value);

--- a/src/subscribable.rs
+++ b/src/subscribable.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 /// `Item` the type of the elements being emitted.
 /// `Err`the type of the error may propagating.
 pub trait Observer<Item, Err> {
-  fn next(&mut self, value: &Item);
+  fn next(&mut self, value: &mut Item);
   fn error(&mut self, err: &Err);
   fn complete(&mut self);
 }
@@ -33,7 +33,7 @@ pub trait RawSubscribable<Item, Err, Subscriber> {
 
 impl<'a, Item, Err> Observer<Item, Err> for Box<dyn Observer<Item, Err> + 'a> {
   #[inline(always)]
-  fn next(&mut self, value: &Item) { (&mut **self).next(value); }
+  fn next(&mut self, value: &mut Item) { (&mut **self).next(value); }
   #[inline(always)]
   fn error(&mut self, err: &Err) { (&mut **self).error(err); }
   #[inline(always)]
@@ -44,7 +44,7 @@ impl<Item, Err> Observer<Item, Err>
   for Box<dyn Observer<Item, Err> + Send + Sync>
 {
   #[inline(always)]
-  fn next(&mut self, value: &Item) { (&mut **self).next(value); }
+  fn next(&mut self, value: &mut Item) { (&mut **self).next(value); }
   #[inline(always)]
   fn error(&mut self, err: &Err) { (&mut **self).error(err); }
   #[inline(always)]
@@ -55,7 +55,7 @@ impl<Item, Err, S> Observer<Item, Err> for Arc<Mutex<S>>
 where
   S: Observer<Item, Err>,
 {
-  fn next(&mut self, value: &Item) { self.lock().unwrap().next(value); }
+  fn next(&mut self, value: &mut Item) { self.lock().unwrap().next(value); }
   fn error(&mut self, err: &Err) { self.lock().unwrap().error(err); }
   fn complete(&mut self) { self.lock().unwrap().complete(); }
 }
@@ -64,7 +64,7 @@ impl<Item, Err, S> Observer<Item, Err> for Rc<RefCell<S>>
 where
   S: Observer<Item, Err>,
 {
-  fn next(&mut self, value: &Item) { self.borrow_mut().next(value); }
+  fn next(&mut self, value: &mut Item) { self.borrow_mut().next(value); }
   fn error(&mut self, err: &Err) { self.borrow_mut().error(err); }
   fn complete(&mut self) { self.borrow_mut().complete(); }
 }

--- a/src/subscribable/subscribable_all.rs
+++ b/src/subscribable/subscribable_all.rs
@@ -29,12 +29,12 @@ where
 
 impl<Item, Err, N, E, C> Observer<Item, Err> for SubscribeAll<N, E, C>
 where
-  N: FnMut(&Item),
+  N: FnMut(&mut Item),
   E: FnMut(&Err),
   C: FnMut(),
 {
   #[inline(always)]
-  fn next(&mut self, value: &Item) { (self.next)(value); }
+  fn next(&mut self, value: &mut Item) { (self.next)(value); }
   #[inline(always)]
   fn error(&mut self, err: &Err) { (self.error)(err); }
   #[inline(always)]
@@ -62,7 +62,7 @@ where
     Err,
     Subscriber<SubscribeAll<N, E, C>, LocalSubscription>,
   >,
-  N: FnMut(&Item),
+  N: FnMut(&mut Item),
   E: FnMut(&Err),
   C: FnMut(),
 {

--- a/src/subscribable/subscribable_comp.rs
+++ b/src/subscribable/subscribable_comp.rs
@@ -12,7 +12,7 @@ where
   C: FnMut(),
 {
   #[inline(always)]
-  fn next(&mut self, value: &Item) { (self.next)(value); }
+  fn next(&mut self, value: &mut Item) { (self.next)(value); }
   #[inline(always)]
   fn error(&mut self, _err: &Err) {}
   #[inline(always)]

--- a/src/subscribable/subscribable_err.rs
+++ b/src/subscribable/subscribable_err.rs
@@ -8,11 +8,11 @@ pub struct SubscribeErr<N, E> {
 
 impl<Item, Err, N, E> Observer<Item, Err> for SubscribeErr<N, E>
 where
-  N: FnMut(&Item),
+  N: FnMut(&mut Item),
   E: FnMut(&Err),
 {
   #[inline(always)]
-  fn next(&mut self, value: &Item) { (self.next)(value); }
+  fn next(&mut self, value: &mut Item) { (self.next)(value); }
   #[inline(always)]
   fn error(&mut self, err: &Err) { (self.error)(err); }
   #[inline(always)]
@@ -53,7 +53,7 @@ where
     Err,
     Subscriber<SubscribeErr<N, E>, LocalSubscription>,
   >,
-  N: FnMut(&Item),
+  N: FnMut(&mut Item),
   E: FnMut(&Err),
 {
   type Unsub = S::Unsub;

--- a/src/subscribable/subscribable_pure.rs
+++ b/src/subscribable/subscribable_pure.rs
@@ -5,10 +5,10 @@ pub struct SubscribePure<N>(N);
 
 impl<Item, N> Observer<Item, ()> for SubscribePure<N>
 where
-  N: FnMut(&Item),
+  N: FnMut(&mut Item),
 {
   #[inline(always)]
-  fn next(&mut self, value: &Item) { (self.0)(value); }
+  fn next(&mut self, value: &mut Item) { (self.0)(value); }
   #[inline(always)]
   fn error(&mut self, _err: &()) {}
   #[inline(always)]
@@ -36,7 +36,7 @@ pub trait SubscribablePure<Item, N> {
 impl<Item, S, N> SubscribablePure<Item, N> for S
 where
   S: RawSubscribable<Item, (), Subscriber<SubscribePure<N>, LocalSubscription>>,
-  N: FnMut(&Item),
+  N: FnMut(&mut Item),
 {
   type Unsub = S::Unsub;
   fn subscribe(self, next: N) -> Self::Unsub

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -47,7 +47,7 @@ where
   S: Observer<Item, Err>,
   U: SubscriptionLike,
 {
-  fn next(&mut self, v: &Item) {
+  fn next(&mut self, v: &mut Item) {
     if !self.subscription.is_closed() {
       self.observer.next(v)
     }
@@ -90,11 +90,11 @@ mod test {
   #[test]
   fn shared_next_complete() {
     let (next, _, complete, mut subscriber) = shared_subscriber_creator();
-    subscriber.next(&1);
-    subscriber.next(&2);
+    subscriber.next(&mut 1);
+    subscriber.next(&mut 2);
     subscriber.complete();
-    subscriber.next(&3);
-    subscriber.next(&4);
+    subscriber.next(&mut 3);
+    subscriber.next(&mut 4);
     assert_eq!(*next.lock().unwrap(), 2);
     assert_eq!(*complete.lock().unwrap(), 1);
   }
@@ -102,11 +102,11 @@ mod test {
   #[test]
   fn shared_err_complete() {
     let (next, error, _, mut subscriber) = shared_subscriber_creator();
-    subscriber.next(&1);
-    subscriber.next(&2);
+    subscriber.next(&mut 1);
+    subscriber.next(&mut 2);
     subscriber.error(&());
-    subscriber.next(&3);
-    subscriber.next(&4);
+    subscriber.next(&mut 3);
+    subscriber.next(&mut 4);
 
     assert_eq!(*next.lock().unwrap(), 2);
     assert_eq!(*error.lock().unwrap(), 1);
@@ -124,7 +124,7 @@ mod test {
       err.clone(),
       complete.clone(),
       Subscriber::shared(SubscribeAll::new(
-        move |_: &_| *next.lock().unwrap() += 1,
+        move |_: &mut _| *next.lock().unwrap() += 1,
         move |_: &_| *err.lock().unwrap() += 1,
         move || *complete.lock().unwrap() += 1,
       ))
@@ -138,16 +138,16 @@ mod test {
     let mut complete = 0;
 
     let mut subscriber = Subscriber::local(SubscribeAll::new(
-      |_: &_| next += 1,
+      |_: &mut _| next += 1,
       |_: &i32| {},
       || complete += 1,
     ));
 
-    subscriber.next(&1);
-    subscriber.next(&2);
+    subscriber.next(&mut 1);
+    subscriber.next(&mut 2);
     subscriber.complete();
-    subscriber.next(&3);
-    subscriber.next(&4);
+    subscriber.next(&mut 3);
+    subscriber.next(&mut 4);
     assert_eq!(next, 2);
     assert_eq!(complete, 1);
   }
@@ -158,15 +158,15 @@ mod test {
     let mut err = 0;
 
     let mut subscriber = Subscriber::local(SubscribeErr::new(
-      |_: &_| next += 1,
+      |_: &mut _| next += 1,
       |_: &()| err += 1,
     ));
 
-    subscriber.next(&1);
-    subscriber.next(&2);
+    subscriber.next(&mut 1);
+    subscriber.next(&mut 2);
     subscriber.error(&());
-    subscriber.next(&3);
-    subscriber.next(&4);
+    subscriber.next(&mut 3);
+    subscriber.next(&mut 4);
 
     assert_eq!(next, 2);
     assert_eq!(err, 1);


### PR DESCRIPTION
observer emit item as mut reference let user can change the item.