### PR TITLE
Mut ref elegant

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,5 @@ error_on_line_overflow = true
 error_on_unformatted = true
 max_width = 80
 tab_spaces = 2
-fn_args_density = "Compressed"
 fn_single_line = true
-
 version = "Two"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,7 @@
 //! upstream except `Fork`, so operators always combine a single-chain and can
 //! only subscribe once. We use `Fork` to fork the stream.
 
-#![feature(
-  external_doc,
-  fn_traits,
-  step_trait,
-  unboxed_closures,
-  never_type,
-  drain_filter,
-  test,
-  raw,
-  decl_macro
-)]
+#![feature(external_doc, specialization, drain_filter, test, decl_macro)]
 #[doc(include = "../README.md")]
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,14 +36,14 @@ pub mod prelude {
   pub use crate::ops;
   pub use crate::scheduler::*;
   pub use crate::subject;
-  pub use crate::subject::{LocalSubject, SharedSubject, Subject, SubjectCopy};
+  pub use crate::subject::{LocalSubject, SharedSubject, Subject};
   pub use crate::subscribable;
   pub use crate::subscribable::*;
   pub use crate::subscriber;
   pub use crate::subscriber::Subscriber;
   pub use crate::subscription;
   pub use crate::subscription::*;
-  pub use observer::Observer;
+  pub use observer::{Observer, ObserverComplete, ObserverError, ObserverNext};
   pub use ops::Fork;
 }
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,7 @@
 //! upstream except `Fork`, so operators always combine a single-chain and can
 //! only subscribe once. We use `Fork` to fork the stream.
 
-#![feature(
-  external_doc,
-  specialization,
-  drain_filter,
-  test,
-  never_type,
-  decl_macro
-)]
+#![feature(external_doc, specialization, drain_filter, test, decl_macro)]
 #[doc(include = "../README.md")]
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate lazy_static;
 extern crate float_cmp;
 
 pub mod observable;
+pub mod observer;
 pub mod ops;
 pub mod scheduler;
 pub mod subject;
@@ -31,6 +32,7 @@ pub mod subscription;
 pub mod prelude {
   pub use crate::observable;
   pub use crate::observable::Observable;
+  pub use crate::observer;
   pub use crate::ops;
   pub use crate::scheduler::*;
   pub use crate::subject;
@@ -41,6 +43,7 @@ pub mod prelude {
   pub use crate::subscriber::Subscriber;
   pub use crate::subscription;
   pub use crate::subscription::*;
+  pub use observer::Observer;
   pub use ops::Fork;
 }
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,14 @@
 //! upstream except `Fork`, so operators always combine a single-chain and can
 //! only subscribe once. We use `Fork` to fork the stream.
 
-#![feature(external_doc, specialization, drain_filter, test, decl_macro)]
+#![feature(
+  external_doc,
+  specialization,
+  drain_filter,
+  test,
+  never_type,
+  decl_macro
+)]
 #[doc(include = "../README.md")]
 #[macro_use]
 extern crate lazy_static;

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use crate::subject::{LocalObserver, SharedSubject};
+use crate::subject::{
+  LocalSubjectMutRef, LocalSubjectMutRefErr, LocalSubjectMutRefItem,
+  SharedSubject,
+};
 
 pub struct ConnectableObservable<Source, Subject> {
   source: Source,
@@ -24,13 +27,42 @@ where
   }
 }
 
-impl<S, P>
-  ConnectableObservable<S, Subject<LocalObserver<P>, LocalSubscription>>
-{
+impl<'a, Item, Err, S> ConnectableObservable<S, LocalSubject<'a, Item, Err>> {
   pub fn local(observable: S) -> Self {
     Self {
       source: observable,
-      subject: Subject::local_new(),
+      subject: Subject::local(),
+    }
+  }
+}
+
+impl<'a, Item, Err, S>
+  ConnectableObservable<S, LocalSubjectMutRef<'a, Item, Err>>
+{
+  pub fn local_mut_ref(observable: S) -> Self {
+    Self {
+      source: observable,
+      subject: Subject::local_mut_ref(),
+    }
+  }
+}
+impl<'a, Item, Err, S>
+  ConnectableObservable<S, LocalSubjectMutRefItem<'a, Item, Err>>
+{
+  pub fn local_mut_ref_item(observable: S) -> Self {
+    Self {
+      source: observable,
+      subject: Subject::local_mut_ref_item(),
+    }
+  }
+}
+impl<'a, Item, Err, S>
+  ConnectableObservable<S, LocalSubjectMutRefErr<'a, Item, Err>>
+{
+  pub fn local_mut_ref_err(observable: S) -> Self {
+    Self {
+      source: observable,
+      subject: Subject::local_mut_ref_err(),
     }
   }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -34,42 +34,53 @@ impl<Item, Err, T> Observer<Item, Err> for T where
 {
 }
 
-pub(crate) macro observer_next_proxy_impl($t: ty,  $host_ty: ident, $name:ident, <$($generics: tt),*>) {
-  impl<$($generics ,)* Item> ObserverNext<Item> for $t where $host_ty: ObserverNext<Item> {
+pub(crate) macro observer_next_proxy_impl(
+  $t: ty,  $host_ty: ident, $name:ident, <$($generics: tt),*>) {
+  impl<$($generics ,)* Item> ObserverNext<Item> for $t
+    where $host_ty: ObserverNext<Item> {
     #[inline(always)]
     fn next(&mut self, value: Item) { self.$name.next(value); }
   }
 }
 
-pub(crate) macro observer_error_proxy_impl($t: ty,  $host_ty: ident, $name:ident, <$($generics: tt),*>) {
-  impl<$($generics ,)* Err> ObserverError<Err> for $t where $host_ty: ObserverError<Err> {
+pub(crate) macro observer_error_proxy_impl(
+  $t: ty,  $host_ty: ident, $name:ident, <$($generics: tt),*>) {
+  impl<$($generics ,)* Err> ObserverError<Err> for $t
+    where $host_ty: ObserverError<Err>
+  {
     #[inline(always)]
     fn error(&mut self, err: Err) { self.$name.error(err); }
   }
 }
 
-pub(crate) macro observer_complete_proxy_impl($t: ty, $host_ty: ident, $name: ident, <$($generics: tt),*>) {
-  impl<$($generics),*> ObserverComplete for $t where $host_ty: ObserverComplete {
+pub(crate) macro observer_complete_proxy_impl(
+  $t: ty, $host_ty: ident, $name: ident, <$($generics: tt),*>) {
+  impl<$($generics),*> ObserverComplete for $t
+    where $host_ty: ObserverComplete
+  {
     #[inline(always)]
     fn complete(&mut self) { self.$name.complete(); }
   }
 }
 
-macro observer_next_pointer_proxy_impl($item: ty,$ty: ty, <$($generics: tt),*>) {
+macro observer_next_pointer_proxy_impl(
+  $item: ty,$ty: ty, <$($generics: tt),*>) {
   impl<$($generics),*> ObserverNext<$item> for $ty {
     #[inline(always)]
     fn next(&mut self, value: $item) { (&mut **self).next(value); }
   }
 }
 
-macro observer_error_pointer_proxy_impl($err: ty, $ty: ty, <$($generics: tt),*>) {
+macro observer_error_pointer_proxy_impl(
+  $err: ty, $ty: ty, <$($generics: tt),*>) {
   impl<$($generics),*> ObserverError<$err> for $ty {
     #[inline(always)]
     fn error(&mut self, err: $err) { (&mut **self).error(err); }
   }
 }
 
-macro observer_complete_pointer_proxy_impl($ty: ty, <$($generics: tt),*>) {
+macro observer_complete_pointer_proxy_impl(
+  $ty: ty, <$($generics: tt),*>) {
   impl<$($generics),*> ObserverComplete for $ty {
     #[inline(always)]
   fn complete(&mut self) { (&mut **self).complete(); }
@@ -77,54 +88,84 @@ macro observer_complete_pointer_proxy_impl($ty: ty, <$($generics: tt),*>) {
 }
 
 // implement `Observer` for Box<dyn Observer<Item, Err> + 'a>
-observer_next_pointer_proxy_impl!(Item, Box<dyn Observer<Item, Err> + 'a>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(Err, Box<dyn Observer<Item, Err> + 'a>, <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(Box<dyn Observer<Item, Err> + 'a>, <'a, Item, Err>);
+observer_next_pointer_proxy_impl!(
+  Item, Box<dyn Observer<Item, Err> + 'a>, <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  Err, Box<dyn Observer<Item, Err> + 'a>, <'a, Item, Err>);
+observer_complete_pointer_proxy_impl!(
+  Box<dyn Observer<Item, Err> + 'a>, <'a, Item, Err>);
 
 // implement `Observer for  Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>
-observer_next_pointer_proxy_impl!(&mut Item,  Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(Err, Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
-observer_complete_pointer_proxy_impl!( Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
+observer_next_pointer_proxy_impl!(
+  &mut Item, Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  Err, Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
+observer_complete_pointer_proxy_impl!(
+  Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
 
 // implement `Observer` for  Box<dyn for<'r> Observer<Item, &'r mut  Err> + 'a>
-observer_next_pointer_proxy_impl!(Item, Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(&mut Err, Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
+observer_next_pointer_proxy_impl!(
+  Item, Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  &mut Err, Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
+observer_complete_pointer_proxy_impl!(
+  Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
 
 // implement `Observer and emit mut ref error for  Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a>
-observer_next_pointer_proxy_impl!(&mut Item, Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(&mut Err, Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
+observer_next_pointer_proxy_impl!(
+  &mut Item, Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  &mut Err, Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
+observer_complete_pointer_proxy_impl!(
+  Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
 
 // implement `Observer` for Box<dyn Observer<Item, Err> + Send + Sync>
-observer_next_pointer_proxy_impl!(Item, Box<dyn Observer<Item, Err> + Send + Sync>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(Err, Box<dyn Observer<Item, Err> + Send + Sync>, <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(Box<dyn Observer<Item, Err> + Send + Sync>, <'a, Item, Err>);
+observer_next_pointer_proxy_impl!(
+  Item, Box<dyn Observer<Item, Err> + Send + Sync>, <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  Err, Box<dyn Observer<Item, Err> + Send + Sync>, <'a, Item, Err>);
+observer_complete_pointer_proxy_impl!(
+  Box<dyn Observer<Item, Err> + Send + Sync>, <'a, Item, Err>);
 
 // implement `Observer` for Box<dyn Publisher<Item, Err> + 'a>
-observer_next_pointer_proxy_impl!(Item, Box<dyn Publisher<Item, Err> + 'a>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(Err, Box<dyn Publisher<Item, Err> + 'a>, <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(Box<dyn Publisher<Item, Err> + 'a>, <'a, Item, Err>);
+observer_next_pointer_proxy_impl!(
+  Item, Box<dyn Publisher<Item, Err> + 'a>, <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  Err, Box<dyn Publisher<Item, Err> + 'a>, <'a, Item, Err>);
+observer_complete_pointer_proxy_impl!(
+  Box<dyn Publisher<Item, Err> + 'a>, <'a, Item, Err>);
 
 // implement `Observer` which emit mut ref item for  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>
-observer_next_pointer_proxy_impl!(&mut Item,  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
-observer_error_pointer_proxy_impl!(Err,  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
-observer_complete_pointer_proxy_impl!(Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
+observer_next_pointer_proxy_impl!(
+  &mut Item,  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
+observer_error_pointer_proxy_impl!(
+  Err,  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
+observer_complete_pointer_proxy_impl!(
+  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
 
 // implement `Observer` which emit mut ref error for  Box<dyn for<'r> Publisher<Item, &'r mut  Err> + 'a>
-observer_next_pointer_proxy_impl!(Item, Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(&mut Err, Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
+observer_next_pointer_proxy_impl!(
+  Item, Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  &mut Err, Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
+observer_complete_pointer_proxy_impl!(
+  Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
 
 // implement `Observer` which emit mut ref item and emit mut ref error for  Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a>
-observer_next_pointer_proxy_impl!(&mut Item, Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(&mut Err, Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
+observer_next_pointer_proxy_impl!(
+  &mut Item, Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  &mut Err, Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
+observer_complete_pointer_proxy_impl!(
+  Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
 
 // implement `Observer` for Box<dyn Publisher<Item, Err> + Send + Sync>
-observer_next_pointer_proxy_impl!(Item, Box<dyn Publisher<Item, Err> + Send + Sync>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(Err, Box<dyn Publisher<Item, Err> + Send + Sync>, <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(Box<dyn Publisher<Item, Err> + Send + Sync>, <'a, Item, Err>);
+observer_next_pointer_proxy_impl!(
+  Item, Box<dyn Publisher<Item, Err> + Send + Sync>, <'a, Item, Err>);
+observer_error_pointer_proxy_impl!(
+  Err, Box<dyn Publisher<Item, Err> + Send + Sync>, <'a, Item, Err>);
+observer_complete_pointer_proxy_impl!(
+  Box<dyn Publisher<Item, Err> + Send + Sync>, <'a, Item, Err>);
 
 impl<Item, S> ObserverNext<Item> for Arc<Mutex<S>>
 where

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -1,0 +1,104 @@
+use crate::subscription::Publisher;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+/// An Observer is a consumer of values delivered by an Observable. One for each
+/// type of notification delivered by the Observable: `next`, `error`,
+/// and `complete`.
+///
+/// `Item` the type of the elements being emitted.
+/// `Err`the type of the error may propagating.
+pub trait Observer<Item, Err> {
+  fn next(&mut self, value: Item);
+  fn error(&mut self, err: Err);
+  fn complete(&mut self);
+}
+
+/// ObserverNext can consume the items delivered by an Observable.
+pub trait ObserverNext<Item> {
+  fn next(&mut self, value: Item);
+}
+
+/// ObserverNext can consume the error delivered by an Observable.
+pub trait ObserverError<Err> {
+  fn error(&mut self, err: Err);
+}
+
+/// ObserverNext can consume the complete notify delivered by an Observable.
+pub trait ObserverComplete {
+  fn complete(&mut self);
+}
+
+impl<Item, Err, T> Observer<Item, Err> for T
+where
+  T: ObserverNext<Item> + ObserverError<Err> + ObserverComplete,
+{
+  #[inline(always)]
+  fn next(&mut self, value: Item) { self.next(value); }
+  #[inline(always)]
+  fn error(&mut self, err: Err) { self.error(err); }
+  #[inline(always)]
+  fn complete(&mut self) { self.complete() }
+}
+
+macro observer_impl_proxy_directly($item: ty, $err: ty) {
+  #[inline(always)]
+  fn next(&mut self, value: $item) { (&mut **self).next(value); }
+  #[inline(always)]
+  fn error(&mut self, err: $err) { (&mut **self).error(err); }
+  #[inline(always)]
+  fn complete(&mut self) { (&mut **self).complete(); }
+}
+
+impl<'a, Item, Err> Observer<Item, Err> for Box<dyn Observer<Item, Err> + 'a> {
+  observer_impl_proxy_directly!(Item, Err);
+}
+
+impl<'a, Item, Err> Observer<Item, Err> for Box<dyn Publisher<Item, Err> + 'a> {
+  observer_impl_proxy_directly!(Item, Err);
+}
+
+impl<'a, Item, Err> Observer<&mut Item, Err>
+  for Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>
+{
+  observer_impl_proxy_directly!(&mut Item, Err);
+}
+impl<'a, Item, Err> Observer<Item, &mut Err>
+  for Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>
+{
+  observer_impl_proxy_directly!(Item, &mut Err);
+}
+impl<'a, Item, Err> Observer<&mut Item, &mut Err>
+  for Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a>
+{
+  observer_impl_proxy_directly!(&mut Item, &mut Err);
+}
+impl<Item, Err> Observer<Item, Err>
+  for Box<dyn Observer<Item, Err> + Send + Sync>
+{
+  observer_impl_proxy_directly!(Item, Err);
+}
+impl<Item, Err> Observer<Item, Err>
+  for Box<dyn Publisher<Item, Err> + Send + Sync>
+{
+  observer_impl_proxy_directly!(Item, Err);
+}
+
+impl<Item, Err, S> Observer<Item, Err> for Arc<Mutex<S>>
+where
+  S: Observer<Item, Err>,
+{
+  fn next(&mut self, value: Item) { self.lock().unwrap().next(value); }
+  fn error(&mut self, err: Err) { self.lock().unwrap().error(err); }
+  fn complete(&mut self) { self.lock().unwrap().complete(); }
+}
+
+impl<Item, Err, S> Observer<Item, Err> for Rc<RefCell<S>>
+where
+  S: Observer<Item, Err>,
+{
+  fn next(&mut self, value: Item) { self.borrow_mut().next(value); }
+  fn error(&mut self, err: Err) { self.borrow_mut().error(err); }
+  fn complete(&mut self) { self.borrow_mut().complete(); }
+}

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -1,3 +1,6 @@
+use crate::observer::{
+  observer_complete_proxy_impl, observer_error_proxy_impl,
+};
 use crate::prelude::*;
 use ops::SharedOp;
 
@@ -61,9 +64,9 @@ pub struct FilterObserver<S, F> {
   filter: F,
 }
 
-impl<Item, Err, S, F> Observer<Item, Err> for FilterObserver<S, F>
+impl<Item, O, F> ObserverNext<Item> for FilterObserver<O, F>
 where
-  S: Observer<Item, Err>,
+  O: ObserverNext<Item>,
   F: FnMut(&Item) -> bool,
 {
   fn next(&mut self, value: Item) {
@@ -71,11 +74,10 @@ where
       self.observer.next(value)
     }
   }
-  #[inline(always)]
-  fn error(&mut self, err: Err) { self.observer.error(err); }
-  #[inline(always)]
-  fn complete(&mut self) { self.observer.complete(); }
 }
+
+observer_error_proxy_impl!(FilterObserver<O, F>, O, observer, <O, F>);
+observer_complete_proxy_impl!(FilterObserver<O, F>, O, observer, <O, F>);
 
 impl<S, F> Fork for FilterOp<S, F>
 where

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -139,7 +139,8 @@ where
 }
 
 observer_error_proxy_impl!(FilterMapObserver<O, F>, O, down_observer, <O, F>);
-observer_complete_proxy_impl!(FilterMapObserver<O, F>, O, down_observer, <O, F>);
+observer_complete_proxy_impl!(
+  FilterMapObserver<O, F>, O, down_observer, <O, F>);
 
 impl<O, F> IntoShared for FilterMapObserver<O, F>
 where
@@ -188,5 +189,15 @@ mod test {
       .fork()
       .to_shared()
       .subscribe(|_| {});
+  }
+  #[test]
+  fn filter_map_mut_ref() {
+    use crate::subject::LocalSubjectMutRefItem;
+
+    let subject: LocalSubjectMutRefItem<'_, i32, ()> =
+      Subject::local_mut_ref_item();
+    subject
+      .filter_map((|v| Some(v)) as fn(v: &mut i32) -> Option<&mut i32>)
+      .subscribe(|_: &mut _| {});
   }
 }

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -1,3 +1,6 @@
+use crate::observer::{
+  observer_complete_proxy_impl, observer_error_proxy_impl,
+};
 use crate::ops::SharedOp;
 use crate::prelude::*;
 use std::marker::PhantomData;
@@ -123,11 +126,9 @@ pub struct FilterMapObserver<O, F> {
   down_observer: O,
   f: F,
 }
-
-impl<O, F, Item, Err, OutputItem> Observer<Item, Err>
-  for FilterMapObserver<O, F>
+impl<O, F, Item, OutputItem> ObserverNext<Item> for FilterMapObserver<O, F>
 where
-  O: Observer<OutputItem, Err>,
+  O: ObserverNext<OutputItem>,
   F: FnMut(Item) -> Option<OutputItem>,
 {
   fn next(&mut self, value: Item) {
@@ -135,11 +136,10 @@ where
       self.down_observer.next(v)
     }
   }
-  #[inline(always)]
-  fn error(&mut self, err: Err) { self.down_observer.error(err) }
-  #[inline(always)]
-  fn complete(&mut self) { self.down_observer.complete() }
 }
+
+observer_error_proxy_impl!(FilterMapObserver<O, F>, O, down_observer, <O, F>);
+observer_complete_proxy_impl!(FilterMapObserver<O, F>, O, down_observer, <O, F>);
 
 impl<O, F> IntoShared for FilterMapObserver<O, F>
 where

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -1,3 +1,6 @@
+use crate::observer::{
+  observer_complete_proxy_impl, observer_error_proxy_impl,
+};
 use crate::prelude::*;
 use ops::SharedOp;
 use std::marker::PhantomData;
@@ -49,19 +52,16 @@ pub struct MapObserver<S, M> {
   map: M,
 }
 
-impl<Item, Err, S, M, B> Observer<Item, Err> for MapObserver<S, M>
+impl<Item, S, M, B> ObserverNext<Item> for MapObserver<S, M>
 where
-  S: Observer<B, Err>,
+  S: ObserverNext<B>,
   M: FnMut(Item) -> B,
 {
   fn next(&mut self, value: Item) { self.observer.next((self.map)(value)) }
-
-  #[inline(always)]
-  fn error(&mut self, err: Err) { self.observer.error(err); }
-
-  #[inline(always)]
-  fn complete(&mut self) { self.observer.complete(); }
 }
+
+observer_complete_proxy_impl!(MapObserver<O, M>, O, observer, <O, M>);
+observer_error_proxy_impl!(MapObserver<O, M>, O, observer, <O, M>);
 
 impl<S, M, B> Fork for MapOp<S, M, B>
 where

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -74,11 +74,10 @@ where
   fn to_shared(self) -> Self { self }
 }
 
-impl<Item, Err, O, SD> Observer<Item, Err> for ObserveOnSubscribe<O, SD>
+impl<Item, O, SD> ObserverNext<Item> for ObserveOnSubscribe<O, SD>
 where
-  O: Observer<Item, Err> + Send + Sync + 'static,
   Item: Clone + Send + Sync + 'static,
-  Err: Clone + Send + Sync + 'static,
+  O: ObserverNext<Item> + Send + Sync + 'static,
   SD: Scheduler,
 {
   fn next(&mut self, value: Item) {
@@ -94,6 +93,14 @@ where
     );
     self.proxy.add(s);
   }
+}
+
+impl<Err, O, SD> ObserverError<Err> for ObserveOnSubscribe<O, SD>
+where
+  O: ObserverError<Err> + Send + Sync + 'static,
+  Err: Clone + Send + Sync + 'static,
+  SD: Scheduler,
+{
   fn error(&mut self, err: Err) {
     let s = self.scheduler.schedule(
       |mut subscription, state| {
@@ -108,6 +115,13 @@ where
     );
     self.proxy.add(s);
   }
+}
+
+impl<O, SD> ObserverComplete for ObserveOnSubscribe<O, SD>
+where
+  O: ObserverComplete + Send + Sync + 'static,
+  SD: Scheduler,
+{
   fn complete(&mut self) {
     let s = self.scheduler.schedule(
       |mut subscription, observer| {

--- a/src/ops/publish.rs
+++ b/src/ops/publish.rs
@@ -6,46 +6,42 @@
 ///
 use crate::observable::connectable_observable::ConnectableObservable;
 pub use crate::prelude::*;
-use crate::subject::LocalObserver;
+use crate::subject::{
+  LocalSubjectMutRef, LocalSubjectMutRefErr, LocalSubjectMutRefItem,
+};
 
-pub trait Publish
+pub trait Publish<'a, Item, Err>
 where
   Self: Sized,
 {
   #[inline(always)]
-  fn publish<'a, Item, Err>(
-    self,
-  ) -> ConnectableObservable<Self, LocalSubject<'a, Item, Err>> {
-    self.publish_raw()
+  fn publish(self) -> ConnectableObservable<Self, LocalSubject<'a, Item, Err>> {
+    ConnectableObservable::local(self)
   }
 
-  /// publish_raw let you can give an explicit box `Publisher` type to the
-  /// `ConnectableObservable`, for most scenes use `publish` is enough, but when
-  /// you pass a mut reference item or error, you can use `publish_raw` to give
-  /// a box trait type for `Subject`
-  /// ```ignore
-  /// use rxrust::prelude::*;
-  /// use rxrust::observable::Connect;
-  /// use rxrust::subscription::Publisher;
-  /// use rxrust::ops::{Publish};
-  ///
-  /// let p = observable::of(100)
-  ///   .publish_raw::<Box<dyn for<'r> Publisher<&'r mut i32, _>>>();
-  /// let mut first = 0;
-  /// let mut second = 0;
-  /// p.fork().subscribe(|v| first = *v);
-  /// p.fork().subscribe(|v| second = *v);
-  /// ```
   #[inline(always)]
-  fn publish_raw<P>(
+  fn publish_mut_ref(
     self,
-  ) -> ConnectableObservable<Self, Subject<LocalObserver<P>, LocalSubscription>>
-  {
-    ConnectableObservable::local(self)
+  ) -> ConnectableObservable<Self, LocalSubjectMutRef<'a, Item, Err>> {
+    ConnectableObservable::local_mut_ref(self)
+  }
+
+  #[inline(always)]
+  fn publish_mut_ref_item(
+    self,
+  ) -> ConnectableObservable<Self, LocalSubjectMutRefItem<'a, Item, Err>> {
+    ConnectableObservable::local_mut_ref_item(self)
+  }
+
+  #[inline(always)]
+  fn publish_mut_ref_err(
+    self,
+  ) -> ConnectableObservable<Self, LocalSubjectMutRefErr<'a, Item, Err>> {
+    ConnectableObservable::local_mut_ref_err(self)
   }
 }
 
-impl<T> Publish for T {}
+impl<'a, Item, Err, T> Publish<'a, Item, Err> for T {}
 
 #[test]
 fn smoke() {

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -266,17 +266,14 @@ fn fork_and_shared() {
 #[test]
 fn filter() {
   use crate::ops::{FilterMap, Publish};
-  use subject::LocalObserver;
-  type MutRefObserver<Item> = Box<dyn for<'r> Publisher<&'r mut Item, ()>>;
-  let mut subject: Subject<LocalObserver<MutRefObserver<i32>>, _> =
-    Subject::local_new();
+  let mut subject = Subject::local_mut_ref();
 
   subject
-    .clone()
     .fork()
     .filter_map((|v: &mut i32| Some(v)) as fn(v: &mut i32) -> Option<&mut i32>)
-    .publish_raw::<MutRefObserver<i32>>()
+    .publish_mut_ref()
     .ref_count();
 
   subject.next(&mut 1);
+  subject.error(&mut 2);
 }

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -270,7 +270,7 @@ fn filter() {
 
   subject
     .fork()
-    .filter_map(|v: &mut i32| Some(v))
+    .filter_map::<_, &mut i32, _>(Some)
     .publish_mut_ref()
     .subscribe_err(|_: &mut i32| {}, |_: &mut i32| {});
 

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -270,7 +270,7 @@ fn filter() {
 
   subject
     .fork()
-    .filter_map((|v: &mut _| Some(v)) as fn(v: &mut i32) -> Option<&mut i32>)
+    .filter_map(|v: &mut i32| Some(v))
     .publish_mut_ref()
     .subscribe_err(|_: &mut i32| {}, |_: &mut i32| {});
 

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -270,9 +270,9 @@ fn filter() {
 
   subject
     .fork()
-    .filter_map((|v: &mut i32| Some(v)) as fn(v: &mut i32) -> Option<&mut i32>)
+    .filter_map((|v: &mut _| Some(v)) as fn(v: &mut i32) -> Option<&mut i32>)
     .publish_mut_ref()
-    .ref_count();
+    .subscribe_err(|_: &mut i32| {}, |_: &mut i32| {});
 
   subject.next(&mut 1);
   subject.error(&mut 2);

--- a/src/ops/scan.rs
+++ b/src/ops/scan.rs
@@ -148,8 +148,10 @@ where
   }
 }
 
-observer_error_proxy_impl!(ScanObserver<Source, BinaryOp, OutputItem>, Source, target_observer, <Source, BinaryOp, OutputItem>);
-observer_complete_proxy_impl!(ScanObserver<Source, BinaryOp, OutputItem>, Source, target_observer, <Source, BinaryOp, OutputItem>);
+observer_error_proxy_impl!(ScanObserver<Source, BinaryOp, OutputItem>,
+  Source, target_observer, <Source, BinaryOp, OutputItem>);
+observer_complete_proxy_impl!(ScanObserver<Source, BinaryOp, OutputItem>,
+  Source, target_observer, <Source, BinaryOp, OutputItem>);
 
 impl<Source, BinaryOp, InputItem, OutputItem> Fork
   for ScanOp<Source, BinaryOp, InputItem, OutputItem>

--- a/src/ops/take.rs
+++ b/src/ops/take.rs
@@ -1,3 +1,6 @@
+use crate::observer::{
+  observer_complete_proxy_impl, observer_error_proxy_impl,
+};
 use crate::ops::SharedOp;
 use crate::prelude::*;
 /// Emits only the first `count` values emitted by the source Observable.
@@ -101,10 +104,10 @@ where
   }
 }
 
-impl<S, ST, Item, Err> Observer<Item, Err> for TakeObserver<S, ST>
+impl<Item, O, U> ObserverNext<Item> for TakeObserver<O, U>
 where
-  S: Observer<Item, Err>,
-  ST: SubscriptionLike,
+  O: ObserverNext<Item> + ObserverComplete,
+  U: SubscriptionLike,
 {
   fn next(&mut self, value: Item) {
     if self.hits < self.count {
@@ -116,11 +119,10 @@ where
       }
     }
   }
-  #[inline(always)]
-  fn error(&mut self, err: Err) { self.observer.error(err); }
-  #[inline(always)]
-  fn complete(&mut self) { self.observer.complete(); }
 }
+
+observer_error_proxy_impl!(TakeObserver<O, U>, O, observer, <O,U>);
+observer_complete_proxy_impl!(TakeObserver<O, U>, O,  observer, <O,U>);
 
 impl<S> Fork for TakeOp<S>
 where

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -140,9 +140,9 @@ where
   fn to_shared(self) -> Self::Shared { self }
 }
 
-impl<O, Item, Err> Observer<Item, Err> for ThrottleTimeObserver<O, Item>
+impl<O, Item> ObserverNext<Item> for ThrottleTimeObserver<O, Item>
 where
-  O: Observer<Item, Err> + Send + 'static,
+  O: ObserverNext<Item> + Send + 'static,
   Item: Clone + Send + 'static,
 {
   fn next(&mut self, value: Item) {
@@ -174,11 +174,22 @@ where
       }
     }
   }
+}
 
+impl<O, Item, Err> ObserverError<Err> for ThrottleTimeObserver<O, Item>
+where
+  O: ObserverError<Err>,
+{
   fn error(&mut self, err: Err) {
     let mut inner = self.0.lock().unwrap();
     inner.observer.error(err)
   }
+}
+
+impl<O, Item> ObserverComplete for ThrottleTimeObserver<O, Item>
+where
+  O: ObserverComplete + ObserverNext<Item>,
+{
   fn complete(&mut self) {
     let mut inner = self.0.lock().unwrap();
     if let Some(value) = inner.trailing_value.take() {

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -20,18 +20,21 @@ pub struct LocalSubjectVec<'a, Item, Err>(
 );
 pub type LocalSubject<'a, Item, Err> = LSubject<LocalSubjectVec<'a, Item, Err>>;
 
+#[allow(clippy::type_complexity)]
 pub struct LocalSubjectMutRefVec<'a, Item, Err>(
   Vec<Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a>>,
 );
 pub type LocalSubjectMutRef<'a, Item, Err> =
   LSubject<LocalSubjectMutRefVec<'a, Item, Err>>;
 
+#[allow(clippy::type_complexity)]
 pub struct LocalSubjectMutRefItemVec<'a, Item, Err>(
   Vec<Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>>,
 );
 pub type LocalSubjectMutRefItem<'a, Item, Err> =
   LSubject<LocalSubjectMutRefItemVec<'a, Item, Err>>;
 
+#[allow(clippy::type_complexity)]
 pub struct LocalSubjectMutRefErrVec<'a, Item, Err>(
   Vec<Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>>,
 );

--- a/src/subscribable.rs
+++ b/src/subscribable.rs
@@ -12,12 +12,43 @@ pub use subscribable_comp::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+/// An Observer is a consumer of values delivered by an Observable. One for each
+/// type of notification delivered by the Observable: `next`, `error`,
+/// and `complete`.
+///
 /// `Item` the type of the elements being emitted.
 /// `Err`the type of the error may propagating.
 pub trait Observer<Item, Err> {
   fn next(&mut self, value: Item);
   fn error(&mut self, err: Err);
   fn complete(&mut self);
+}
+
+/// ObserverNext can consume the items delivered by an Observable.
+pub trait ObserverNext<Item> {
+  fn next(&mut self, value: Item);
+}
+
+/// ObserverNext can consume the error delivered by an Observable.
+pub trait ObserverError<Err> {
+  fn error(&mut self, err: Err);
+}
+
+/// ObserverNext can consume the complete notify delivered by an Observable.
+pub trait ObserverComplete {
+  fn complete(&mut self);
+}
+
+impl<Item, Err, T> Observer<Item, Err> for T
+where
+  T: ObserverNext<Item> + ObserverError<Err> + ObserverComplete,
+{
+  #[inline(always)]
+  fn next(&mut self, value: Item) { self.next(value); }
+  #[inline(always)]
+  fn error(&mut self, err: Err) { self.error(err); }
+  #[inline(always)]
+  fn complete(&mut self) { self.complete() }
 }
 
 pub trait IntoShared {
@@ -43,24 +74,11 @@ macro observer_impl_proxy_directly($item: ty, $err: ty) {
 impl<'a, Item, Err> Observer<Item, Err> for Box<dyn Observer<Item, Err> + 'a> {
   observer_impl_proxy_directly!(Item, Err);
 }
-impl<'a, Item, Err> Observer<&mut Item, Err>
-  for Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>
-{
-  observer_impl_proxy_directly!(&mut Item, Err);
-}
-impl<'a, Item, Err> Observer<Item, &mut Err>
-  for Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>
-{
-  observer_impl_proxy_directly!(Item, &mut Err);
-}
-impl<'a, Item, Err> Observer<&mut Item, &mut Err>
-  for Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a>
-{
-  observer_impl_proxy_directly!(&mut Item, &mut Err);
-}
+
 impl<'a, Item, Err> Observer<Item, Err> for Box<dyn Publisher<Item, Err> + 'a> {
   observer_impl_proxy_directly!(Item, Err);
 }
+
 impl<'a, Item, Err> Observer<&mut Item, Err>
   for Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>
 {

--- a/src/subscribable.rs
+++ b/src/subscribable.rs
@@ -5,51 +5,10 @@ pub use subscribable_err::*;
 mod subscribable_pure;
 pub use subscribable_pure::*;
 mod subscribable_comp;
-use crate::subscription::{Publisher, SubscriptionLike};
+use crate::observer::Observer;
+use crate::subscription::SubscriptionLike;
 use std::sync::{Arc, Mutex};
 pub use subscribable_comp::*;
-
-use std::cell::RefCell;
-use std::rc::Rc;
-
-/// An Observer is a consumer of values delivered by an Observable. One for each
-/// type of notification delivered by the Observable: `next`, `error`,
-/// and `complete`.
-///
-/// `Item` the type of the elements being emitted.
-/// `Err`the type of the error may propagating.
-pub trait Observer<Item, Err> {
-  fn next(&mut self, value: Item);
-  fn error(&mut self, err: Err);
-  fn complete(&mut self);
-}
-
-/// ObserverNext can consume the items delivered by an Observable.
-pub trait ObserverNext<Item> {
-  fn next(&mut self, value: Item);
-}
-
-/// ObserverNext can consume the error delivered by an Observable.
-pub trait ObserverError<Err> {
-  fn error(&mut self, err: Err);
-}
-
-/// ObserverNext can consume the complete notify delivered by an Observable.
-pub trait ObserverComplete {
-  fn complete(&mut self);
-}
-
-impl<Item, Err, T> Observer<Item, Err> for T
-where
-  T: ObserverNext<Item> + ObserverError<Err> + ObserverComplete,
-{
-  #[inline(always)]
-  fn next(&mut self, value: Item) { self.next(value); }
-  #[inline(always)]
-  fn error(&mut self, err: Err) { self.error(err); }
-  #[inline(always)]
-  fn complete(&mut self) { self.complete() }
-}
 
 pub trait IntoShared {
   type Shared: Sync + Send + 'static;
@@ -60,67 +19,6 @@ pub trait RawSubscribable<Subscriber> {
   /// A type implementing [`SubscriptionLike`]
   type Unsub: SubscriptionLike + 'static;
   fn raw_subscribe(self, subscriber: Subscriber) -> Self::Unsub;
-}
-
-macro observer_impl_proxy_directly($item: ty, $err: ty) {
-  #[inline(always)]
-  fn next(&mut self, value: $item) { (&mut **self).next(value); }
-  #[inline(always)]
-  fn error(&mut self, err: $err) { (&mut **self).error(err); }
-  #[inline(always)]
-  fn complete(&mut self) { (&mut **self).complete(); }
-}
-
-impl<'a, Item, Err> Observer<Item, Err> for Box<dyn Observer<Item, Err> + 'a> {
-  observer_impl_proxy_directly!(Item, Err);
-}
-
-impl<'a, Item, Err> Observer<Item, Err> for Box<dyn Publisher<Item, Err> + 'a> {
-  observer_impl_proxy_directly!(Item, Err);
-}
-
-impl<'a, Item, Err> Observer<&mut Item, Err>
-  for Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>
-{
-  observer_impl_proxy_directly!(&mut Item, Err);
-}
-impl<'a, Item, Err> Observer<Item, &mut Err>
-  for Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>
-{
-  observer_impl_proxy_directly!(Item, &mut Err);
-}
-impl<'a, Item, Err> Observer<&mut Item, &mut Err>
-  for Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a>
-{
-  observer_impl_proxy_directly!(&mut Item, &mut Err);
-}
-impl<Item, Err> Observer<Item, Err>
-  for Box<dyn Observer<Item, Err> + Send + Sync>
-{
-  observer_impl_proxy_directly!(Item, Err);
-}
-impl<Item, Err> Observer<Item, Err>
-  for Box<dyn Publisher<Item, Err> + Send + Sync>
-{
-  observer_impl_proxy_directly!(Item, Err);
-}
-
-impl<Item, Err, S> Observer<Item, Err> for Arc<Mutex<S>>
-where
-  S: Observer<Item, Err>,
-{
-  fn next(&mut self, value: Item) { self.lock().unwrap().next(value); }
-  fn error(&mut self, err: Err) { self.lock().unwrap().error(err); }
-  fn complete(&mut self) { self.lock().unwrap().complete(); }
-}
-
-impl<Item, Err, S> Observer<Item, Err> for Rc<RefCell<S>>
-where
-  S: Observer<Item, Err>,
-{
-  fn next(&mut self, value: Item) { self.borrow_mut().next(value); }
-  fn error(&mut self, err: Err) { self.borrow_mut().error(err); }
-  fn complete(&mut self) { self.borrow_mut().complete(); }
 }
 
 impl<Item, Err> IntoShared for Box<dyn Observer<Item, Err> + Send + Sync>

--- a/src/subscribable/subscribable_all.rs
+++ b/src/subscribable/subscribable_all.rs
@@ -1,5 +1,5 @@
+use crate::observer::{ObserverComplete, ObserverError, ObserverNext};
 use crate::prelude::*;
-use crate::subscribable::{ObserverComplete, ObserverError, ObserverNext};
 
 #[derive(Clone)]
 pub struct SubscribeAll<N, E, C> {

--- a/src/subscribable/subscribable_comp.rs
+++ b/src/subscribable/subscribable_comp.rs
@@ -1,5 +1,5 @@
+use crate::observer::{ObserverComplete, ObserverError, ObserverNext};
 use crate::prelude::*;
-use crate::subscribable::{ObserverComplete, ObserverError, ObserverNext};
 
 #[derive(Clone)]
 pub struct SubscribeComplete<N, C> {

--- a/src/subscribable/subscribable_comp.rs
+++ b/src/subscribable/subscribable_comp.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::subscribable::{ObserverComplete, ObserverError, ObserverNext};
 
 #[derive(Clone)]
 pub struct SubscribeComplete<N, C> {
@@ -6,17 +7,33 @@ pub struct SubscribeComplete<N, C> {
   complete: C,
 }
 
-impl<Item, N, C> Observer<Item, ()> for SubscribeComplete<N, C>
+impl<N, C> ObserverComplete for SubscribeComplete<N, C>
 where
-  N: FnMut(Item),
   C: FnMut(),
 {
   #[inline(always)]
-  fn next(&mut self, value: Item) { (self.next)(value); }
+  fn complete(&mut self) { (self.complete)(); }
+}
+
+impl<N, C> ObserverError<()> for SubscribeComplete<N, C> {
   #[inline(always)]
   fn error(&mut self, _err: ()) {}
+}
+
+impl<N, C, Item> ObserverNext<Item> for SubscribeComplete<N, C>
+where
+  N: FnMut(Item),
+{
   #[inline(always)]
-  fn complete(&mut self) { (self.complete)(); }
+  default fn next(&mut self, value: Item) { (self.next)(value); }
+}
+
+impl<N, C, Item> ObserverNext<&mut Item> for SubscribeComplete<N, C>
+where
+  N: for<'r> FnMut(&'r mut Item),
+{
+  #[inline(always)]
+  fn next(&mut self, value: &mut Item) { (self.next)(value); }
 }
 
 impl<N, C> SubscribeComplete<N, C> {

--- a/src/subscribable/subscribable_err.rs
+++ b/src/subscribable/subscribable_err.rs
@@ -1,5 +1,5 @@
+use crate::observer::{ObserverComplete, ObserverError, ObserverNext};
 use crate::prelude::*;
-use crate::subscribable::{ObserverComplete, ObserverError, ObserverNext};
 
 #[derive(Clone)]
 pub struct SubscribeErr<N, E> {

--- a/src/subscribable/subscribable_pure.rs
+++ b/src/subscribable/subscribable_pure.rs
@@ -1,18 +1,32 @@
 use crate::prelude::*;
+use crate::subscribable::{ObserverComplete, ObserverError, ObserverNext};
 
 #[derive(Clone)]
 pub struct SubscribePure<N>(N);
 
-impl<Item, N> Observer<Item, ()> for SubscribePure<N>
+impl<N> ObserverComplete for SubscribePure<N> {
+  #[inline(always)]
+  fn complete(&mut self) {}
+}
+
+impl<N> ObserverError<()> for SubscribePure<N> {
+  #[inline(always)]
+  fn error(&mut self, _err: ()) {}
+}
+
+impl<N, Item> ObserverNext<Item> for SubscribePure<N>
 where
   N: FnMut(Item),
 {
   #[inline(always)]
-  fn next(&mut self, value: Item) { (self.0)(value); }
-  #[inline(always)]
-  fn error(&mut self, _err: ()) {}
-  #[inline(always)]
-  fn complete(&mut self) {}
+  default fn next(&mut self, value: Item) { (self.0)(value); }
+}
+
+impl<Item, N> ObserverNext<&mut Item> for SubscribePure<N>
+where
+  N: for<'r> FnMut(&'r mut Item),
+{
+  fn next(&mut self, value: &mut Item) { (self.0)(value); }
 }
 
 impl<N> IntoShared for SubscribePure<N>

--- a/src/subscribable/subscribable_pure.rs
+++ b/src/subscribable/subscribable_pure.rs
@@ -1,5 +1,5 @@
+use crate::observer::{ObserverComplete, ObserverError, ObserverNext};
 use crate::prelude::*;
-use crate::subscribable::{ObserverComplete, ObserverError, ObserverNext};
 
 #[derive(Clone)]
 pub struct SubscribePure<N>(N);

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -42,9 +42,9 @@ where
   }
 }
 
-impl<Item, Err, S, U> Observer<Item, Err> for Subscriber<S, U>
+impl<Item, O, U> ObserverNext<Item> for Subscriber<O, U>
 where
-  S: Observer<Item, Err>,
+  O: ObserverNext<Item>,
   U: SubscriptionLike,
 {
   fn next(&mut self, v: Item) {
@@ -52,18 +52,30 @@ where
       self.observer.next(v)
     }
   }
+}
 
-  fn complete(&mut self) {
-    if !self.subscription.is_closed() {
-      self.observer.complete();
-      self.subscription.unsubscribe()
-    }
-  }
-
+impl<Err, O, U> ObserverError<Err> for Subscriber<O, U>
+where
+  O: ObserverError<Err>,
+  U: SubscriptionLike,
+{
   fn error(&mut self, err: Err) {
     if !self.subscription.is_closed() {
       self.observer.error(err);
       self.subscription.unsubscribe();
+    }
+  }
+}
+
+impl<O, U> ObserverComplete for Subscriber<O, U>
+where
+  O: ObserverComplete,
+  U: SubscriptionLike,
+{
+  fn complete(&mut self) {
+    if !self.subscription.is_closed() {
+      self.observer.complete();
+      self.subscription.unsubscribe()
     }
   }
 }


### PR DESCRIPTION
This pr resolve two problem of subject emit mut ref item.

1.  When use subject emit mut ref item or mut ref error, infer type not work, we must write like this

```rust
    // emit mut ref
    type MutRefObserver<Item> = Box<dyn for<'r> Publisher<&'r mut Item, ()>>;
    let mut subject: Subject<LocalObserver<MutRefObserver<i32>>, _> =
      Subject::local_new();

    subject
      .fork()
      .subscribe((|_: &mut _| {}) as for<'r> fn(&'r mut i32));
    subject.next(&mut 1);
```
A more elegant way should like this:

``` rust
    // emit mut ref
    let mut subject = Subject::local_mut_ref_item();
    subject.fork().subscribe(|_: &mut _| {});
    subject.next(&mut 1);
```

2. We introduced a trait `SubjectCopy` in 0.7.1,  but only primitive and `&mut T` auto  implemented it, and a type must implemented `SubjectCopy` can be emit by `Subject`,  this is a uglify limit, every type implemented `Copy` can be emitted by `Subject`.