### PR TITLE
Update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [Unreleased](https://github.com/M-Adoo/rxRust/compare/v0.7.0...HEAD)
+## [Unreleased](https://github.com/rxRust/rxRust/compare/v0.7.0...HEAD)
 
-## [0.7.0](https://github.com/M-Adoo/rxRust/releases/tag/v0.7.0)  (2019-12-12)
+## [0.7.0](https://github.com/rxRust/rxRust/releases/tag/v0.7.0)  (2019-12-12)
 
 ### Features
 
@@ -11,7 +11,7 @@
 - **observable**: `LocalConnectableObservable` and `SharedConnectableObservable` has merged into `ConnectableObservable`
 - **observable**: remove generic type `Item` and `Err` from `RawSubscribable`, almost not effect user code.
 
-## [0.6.0](https://github.com/M-Adoo/rxRust/releases/tag/v0.6.0)  (2019-12-07)
+## [0.6.0](https://github.com/rxRust/rxRust/releases/tag/v0.6.0)  (2019-12-07)
 
 ### Breaking Changes
 
@@ -19,7 +19,7 @@
 - **operator**: remove `map_return_ref` operator, now `map` cover its use scenes.
 - **operator**: remove `filter_map_return_ref`, now `filter_map` cover its use scenes.
 
-## [0.5.0](https://github.com/M-Adoo/rxRust/releases/tag/v0.5.0)  (2019-11-19)
+## [0.5.0](https://github.com/rxRust/rxRust/releases/tag/v0.5.0)  (2019-11-19)
 
 ### Features
 - **operator**: add `scan` operator.
@@ -36,7 +36,7 @@
 - **observable**: macros `of!`, `empty!`, `from_iter!`, `from_future!` and
   `from_future_with_errors!` replaced by functions.
 
-## [0.4.0](https://github.com/M-Adoo/rxRust/releases/tag/v0.4.0)  (2019-11-07)
+## [0.4.0](https://github.com/rxRust/rxRust/releases/tag/v0.4.0)  (2019-11-07)
 
 ### Features
 - **observable**: add `ConnectableObservable` to support multicast.
@@ -69,7 +69,7 @@ pub trait Scheduler {
 }
 ```
 
-## [0.3.0](https://github.com/M-Adoo/rxRust/releases/tag/v0.3.0)  (2019-10-12)
+## [0.3.0](https://github.com/rxRust/rxRust/releases/tag/v0.3.0)  (2019-10-12)
 
 ### Code Refactoring
 
@@ -113,7 +113,7 @@ assert_eq!(res, 100);
 - **observe_on**: unsubscribe should also cancel dispatched message.
 - **subscribe_on**: unsubscribe should also cancel task in scheduler queue.
 
-## [0.2.0](https://github.com/M-Adoo/rxRust/releases/tag/v0.2.0)  (2019-09-02)
+## [0.2.0](https://github.com/rxRust/rxRust/releases/tag/v0.2.0)  (2019-09-02)
 
 ### Features
 - **observable**: add `observable::from_vec` and `observable::from_range`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 ## Any contributions you make will be under the MIT Software License
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issues](https://github.com/M-Adoo/rxRust/issues)
+## Report bugs using Github's [issues](https://github.com/rxRust/rxRust/issues)
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](); it's that easy!
 
 ## Write bug reports with detail, background, and sample code

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # RxRust: a zero cost Rust implementation of Reactive Extensions
 [![](https://docs.rs/rxrust/badge.svg)](https://docs.rs/rxrust/)
 [![codecov](https://codecov.io/gh/rxRust/rxRust/branch/master/graph/badge.svg)](https://codecov.io/gh/rxRust/rxRust)
-![](https://github.com/M-Adoo/rxRust/workflows/test/badge.svg)
+![](https://github.com/rxRust/rxRust/workflows/test/badge.svg)
 [![](https://img.shields.io/crates/v/rxrust.svg)](https://crates.io/crates/rxrust)
 [![](https://img.shields.io/crates/d/rxrust.svg)](https://crates.io/crates/rxrust)
 
 ## Usage
 Add this to your Cargo.toml:
 
-```ignore
+```toml
 [dependencies]
-rxrust = "0.7.1";
+rxrust = "0.7.1"
 ```
 
 ## Example 


### PR DESCRIPTION
- Use toml highlight and remove unnecessary `;` from the Usage section on README
- Replace `M-Adoo/rxRust` with `rxRust/rxRust`
