### PR TITLE
refactor: merge 4 version local subject into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-## [Unreleased](https://github.com/rxRust/rxRust/compare/v0.7.0...HEAD)
+## [Unreleased](https://github.com/rxRust/rxRust/compare/v0.7.2...HEAD)
+
+## [0.7.2](https://github.com/rxRust/rxRust/releases/tag/v0.7.1)  (2019-12-12)
+
+### Refactor
+
+- **Subject**: merge four version local subject into same version.
+
+### Breaking Changes
+
+- **Subject**: `Subject::local`,`Subject::local_mut_ref`, `Subject::local_mut_ref_item` and `Subject::local_mut_ref_err` merge into `Subject::local`.
+
+## [0.7.1](https://github.com/rxRust/rxRust/releases/tag/v0.7.1)  (2019-12-12)
+
+**Nothing changed, just fix release package**
 
 ## [0.7.0](https://github.com/rxRust/rxRust/releases/tag/v0.7.0)  (2019-12-12)
 

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -1,8 +1,5 @@
 use crate::prelude::*;
-use crate::subject::{
-  LocalSubjectMutRef, LocalSubjectMutRefErr, LocalSubjectMutRefItem,
-  SharedSubject,
-};
+use crate::subject::{LocalSubject, SharedSubject};
 
 pub struct ConnectableObservable<Source, Subject> {
   source: Source,
@@ -14,15 +11,16 @@ pub trait Connect {
   fn connect(self) -> Self::Unsub;
 }
 
-impl<S, O, U, Subscriber> RawSubscribable<Subscriber>
+impl<S, O, U, Sub> RawSubscribable<Sub>
   for ConnectableObservable<S, Subject<O, U>>
 where
-  Subject<O, U>: RawSubscribable<Subscriber>,
+  S: RawSubscribable<Subscriber<O, U>>,
+  Subject<O, U>: RawSubscribable<Sub>,
 {
-  type Unsub = <Subject<O, U> as RawSubscribable<Subscriber>>::Unsub;
+  type Unsub = <Subject<O, U> as RawSubscribable<Sub>>::Unsub;
 
   #[inline(always)]
-  fn raw_subscribe(self, subscriber: Subscriber) -> Self::Unsub {
+  fn raw_subscribe(self, subscriber: Sub) -> Self::Unsub {
     self.subject.raw_subscribe(subscriber)
   }
 }
@@ -32,37 +30,6 @@ impl<'a, Item, Err, S> ConnectableObservable<S, LocalSubject<'a, Item, Err>> {
     Self {
       source: observable,
       subject: Subject::local(),
-    }
-  }
-}
-
-impl<'a, Item, Err, S>
-  ConnectableObservable<S, LocalSubjectMutRef<'a, Item, Err>>
-{
-  pub fn local_mut_ref(observable: S) -> Self {
-    Self {
-      source: observable,
-      subject: Subject::local_mut_ref(),
-    }
-  }
-}
-impl<'a, Item, Err, S>
-  ConnectableObservable<S, LocalSubjectMutRefItem<'a, Item, Err>>
-{
-  pub fn local_mut_ref_item(observable: S) -> Self {
-    Self {
-      source: observable,
-      subject: Subject::local_mut_ref_item(),
-    }
-  }
-}
-impl<'a, Item, Err, S>
-  ConnectableObservable<S, LocalSubjectMutRefErr<'a, Item, Err>>
-{
-  pub fn local_mut_ref_err(observable: S) -> Self {
-    Self {
-      source: observable,
-      subject: Subject::local_mut_ref_err(),
     }
   }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -54,7 +54,7 @@ pub(crate) macro observer_error_proxy_impl(
 }
 
 pub(crate) macro observer_complete_proxy_impl(
-  $t: ty, $host_ty: ident, $name: ident, <$($generics: tt),*>) {
+  $t: ty, $host_ty: ident, $name: tt, <$($generics: tt),*>) {
   impl<$($generics),*> ObserverComplete for $t
     where $host_ty: ObserverComplete
   {
@@ -95,30 +95,6 @@ observer_error_pointer_proxy_impl!(
 observer_complete_pointer_proxy_impl!(
   Box<dyn Observer<Item, Err> + 'a>, <'a, Item, Err>);
 
-// implement `Observer for  Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>
-observer_next_pointer_proxy_impl!(
-  &mut Item, Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(
-  Err, Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
-observer_complete_pointer_proxy_impl!(
-  Box<dyn for<'r> Observer<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
-
-// implement `Observer` for  Box<dyn for<'r> Observer<Item, &'r mut  Err> + 'a>
-observer_next_pointer_proxy_impl!(
-  Item, Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(
-  &mut Err, Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(
-  Box<dyn for<'r> Observer<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-
-// implement `Observer and emit mut ref error for  Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a>
-observer_next_pointer_proxy_impl!(
-  &mut Item, Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(
-  &mut Err, Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(
-  Box<dyn for<'r> Observer<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-
 // implement `Observer` for Box<dyn Observer<Item, Err> + Send + Sync>
 observer_next_pointer_proxy_impl!(
   Item, Box<dyn Observer<Item, Err> + Send + Sync>, <'a, Item, Err>);
@@ -134,30 +110,6 @@ observer_error_pointer_proxy_impl!(
   Err, Box<dyn Publisher<Item, Err> + 'a>, <'a, Item, Err>);
 observer_complete_pointer_proxy_impl!(
   Box<dyn Publisher<Item, Err> + 'a>, <'a, Item, Err>);
-
-// implement `Observer` which emit mut ref item for  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>
-observer_next_pointer_proxy_impl!(
-  &mut Item,  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
-observer_error_pointer_proxy_impl!(
-  Err,  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
-observer_complete_pointer_proxy_impl!(
-  Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>, <'a, Item, Err> );
-
-// implement `Observer` which emit mut ref error for  Box<dyn for<'r> Publisher<Item, &'r mut  Err> + 'a>
-observer_next_pointer_proxy_impl!(
-  Item, Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(
-  &mut Err, Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(
-  Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>, <'a, Item, Err>);
-
-// implement `Observer` which emit mut ref item and emit mut ref error for  Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a>
-observer_next_pointer_proxy_impl!(
-  &mut Item, Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-observer_error_pointer_proxy_impl!(
-  &mut Err, Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
-observer_complete_pointer_proxy_impl!(
-  Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a> , <'a, Item, Err>);
 
 // implement `Observer` for Box<dyn Publisher<Item, Err> + Send + Sync>
 observer_next_pointer_proxy_impl!(

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -192,12 +192,12 @@ mod test {
   }
   #[test]
   fn filter_map_mut_ref() {
-    use crate::subject::LocalSubjectMutRefItem;
-
-    let subject: LocalSubjectMutRefItem<'_, i32, ()> =
-      Subject::local_mut_ref_item();
+    let mut subject = Subject::local();
     subject
-      .filter_map((|v| Some(v)) as fn(v: &mut i32) -> Option<&mut i32>)
-      .subscribe(|_: &mut _| {});
+      .fork()
+      .filter_map::<fn(&mut i32) -> Option<&mut i32>, _, _>(|v| Some(v))
+      .subscribe(|_: &mut i32| {});
+
+    subject.next(&mut 1);
   }
 }

--- a/src/ops/publish.rs
+++ b/src/ops/publish.rs
@@ -6,42 +6,17 @@
 ///
 use crate::observable::connectable_observable::ConnectableObservable;
 pub use crate::prelude::*;
-use crate::subject::{
-  LocalSubjectMutRef, LocalSubjectMutRefErr, LocalSubjectMutRefItem,
-};
 
-pub trait Publish<'a, Item, Err>
-where
-  Self: Sized,
-{
+pub trait Publish<'a, Item, Err>: Sized {
+  fn publish(self) -> ConnectableObservable<Self, LocalSubject<'a, Item, Err>>;
+}
+
+impl<'a, Item, Err, T> Publish<'a, Item, Err> for T {
   #[inline(always)]
   fn publish(self) -> ConnectableObservable<Self, LocalSubject<'a, Item, Err>> {
     ConnectableObservable::local(self)
   }
-
-  #[inline(always)]
-  fn publish_mut_ref(
-    self,
-  ) -> ConnectableObservable<Self, LocalSubjectMutRef<'a, Item, Err>> {
-    ConnectableObservable::local_mut_ref(self)
-  }
-
-  #[inline(always)]
-  fn publish_mut_ref_item(
-    self,
-  ) -> ConnectableObservable<Self, LocalSubjectMutRefItem<'a, Item, Err>> {
-    ConnectableObservable::local_mut_ref_item(self)
-  }
-
-  #[inline(always)]
-  fn publish_mut_ref_err(
-    self,
-  ) -> ConnectableObservable<Self, LocalSubjectMutRefErr<'a, Item, Err>> {
-    ConnectableObservable::local_mut_ref_err(self)
-  }
 }
-
-impl<'a, Item, Err, T> Publish<'a, Item, Err> for T {}
 
 #[test]
 fn smoke() {

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -237,11 +237,11 @@ fn fork_and_shared() {
   use crate::ops::Publish;
   observable::of(1).publish().ref_count().subscribe(|_| {});
 
-  LocalSubject::<'_, (), ()>::local()
+  LocalSubject::local()
     .publish()
     .ref_count()
     .to_shared()
-    .subscribe(|_| {});
+    .subscribe(|_: i32| {});
 
   observable::of(1)
     .publish()
@@ -266,13 +266,13 @@ fn fork_and_shared() {
 #[test]
 fn filter() {
   use crate::ops::{FilterMap, Publish};
-  let mut subject = Subject::local_mut_ref();
+  let mut subject = Subject::local();
 
   subject
     .fork()
-    .filter_map::<_, &mut i32, _>(Some)
-    .publish_mut_ref()
-    .subscribe_err(|_: &mut i32| {}, |_: &mut i32| {});
+    .filter_map::<fn(&mut i32) -> Option<&mut i32>, _, _>(|v| Some(v))
+    .publish()
+    .subscribe_err(|_: &mut _| {}, |_: &mut i32| {});
 
   subject.next(&mut 1);
   subject.error(&mut 2);

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -277,3 +277,13 @@ fn filter() {
   subject.next(&mut 1);
   subject.error(&mut 2);
 }
+
+#[test]
+#[should_panic]
+fn convert_local_ref_count_to_shared_should_panic() {
+  use crate::ops::Publish;
+
+  let ref_count = Subject::local().fork().publish().ref_count();
+  ref_count.fork().subscribe(|_: i32| {});
+  ref_count.to_shared();
+}


### PR DESCRIPTION
This commit merge four version local subject into same one. Now we can emit value by mut ref like this:

```rust 
 let mut i = 1;

 let mut subject = Subject::local();
 subject.fork().subscribe(|v: &mut _| { *v = 100; });
 subject.next(&mut i);

 assert_eq!(i, 100);
```