### PR TITLE
refactor: replace macros interval and interval_at with functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,14 @@
 //! upstream except `Fork`, so operators always combine a single-chain and can
 //! only subscribe once. We use `Fork` to fork the stream.
 
-#![feature(external_doc, specialization, drain_filter, test, decl_macro)]
+#![feature(
+  external_doc,
+  specialization,
+  drain_filter,
+  trait_alias,
+  test,
+  decl_macro
+)]
 #[doc(include = "../README.md")]
 #[macro_use]
 extern crate lazy_static;

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -204,7 +204,7 @@ fn smoke() {
   let x = Arc::new(Mutex::new(vec![]));
   let x_c = x.clone();
 
-  let interval = observable::interval!(Duration::from_millis(5));
+  let interval = observable::interval(Duration::from_millis(5));
   let throttle_subscribe = |edge| {
     let x = x.clone();
     interval

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 /// use rxrust::{ prelude::*, ops::{ ThrottleTime, ThrottleEdge }};
 /// use std::time::Duration;
 ///
-/// observable::interval!(Duration::from_millis(1))
+/// observable::interval(Duration::from_millis(1))
 ///   .throttle_time(Duration::from_millis(9), ThrottleEdge::Leading)
 ///   .subscribe(move |v| println!("{}", v));
 /// ```


### PR DESCRIPTION
This pr replace macros `interval!` and `interval_at!` with functions as I suggested in #23. 

BTW, I notice this project uses generics a lot, but too many generics may slow down compilation when this project grows large. For example, `diesel` use generics a lot and it compiles really slow.  I think compilation time does matter.