### PR TITLE
Replace in-house implementation with smallvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 futures-preview = "=0.3.0-alpha.18"
 lazy_static = "1.3.0"
 futures-timer = "0.3.0"
+smallvec = "1.1.0"
 
 [dev-dependencies]
 float-cmp = "0.5.3"


### PR DESCRIPTION
Replaces the `Teardown` type (probably coded to save space?) with a more generic implementation from the `smallvec` crate.

This makes the implementation less error prone.