### PR TITLE
Refactor concrete observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Breaking Changes
 
-- **observable**: remove `Observable::new`, and add a same `new` function in `observable` to replace it.
+- **observable**: remove `Observable::new`, and add a same `create` function in `observable` to replace it.
 - **observable**: Rename `Observable` to `ObservableFromFn`.
 
 ## [0.7.2](https://github.com/rxRust/rxRust/releases/tag/v0.7.2)  (2020-01-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased](https://github.com/rxRust/rxRust/compare/v0.7.3...HEAD)
 
+### Features
+- **operator**: add `take_last` operator.
+
+### Refactor
+
+- **observable**: Observable split into many concrete type, not only use a Observable struct to wrap all, every observable creating function has a concrete type.
+
+### Breaking Changes
+
+- **observable**: remove `Observable::new`, and add a same `new` function in `observable` to replace it.
+- **observable**: Rename `Observable` to `ObservableFromFn`.
+
 ## [0.7.2](https://github.com/rxRust/rxRust/releases/tag/v0.7.2)  (2020-01-09)
 
 ### Refactor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ pub mod subscription;
 
 pub mod prelude {
   pub use crate::observable;
-  pub use crate::observable::Observable;
   pub use crate::observer;
   pub use crate::ops;
   pub use crate::scheduler::*;

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -37,7 +37,9 @@ impl_observable!(ObservableFromFn);
 /// new values can be `next`ed, or an `error` method can be called to raise
 /// an error, or `complete` can be called to notify of a successful
 /// completion.
-pub fn new<F, Item, Err, S, U>(subscribe: F) -> ObservableFromFn<F, Item, Err>
+pub fn create<F, Item, Err, S, U>(
+  subscribe: F,
+) -> ObservableFromFn<F, Item, Err>
 where
   F: FnOnce(Subscriber<S, U>),
   S: Observer<Item, Err>,
@@ -187,7 +189,7 @@ mod test {
     let c_err = err.clone();
     let c_complete = complete.clone();
 
-    observable::new(|mut subscriber| {
+    observable::create(|mut subscriber| {
       subscriber.next(&1);
       subscriber.next(&2);
       subscriber.next(&3);
@@ -208,7 +210,7 @@ mod test {
   }
   #[test]
   fn support_fork() {
-    let o = observable::new(|mut subscriber| {
+    let o = observable::create(|mut subscriber| {
       subscriber.next(&1);
       subscriber.next(&2);
       subscriber.next(&3);

--- a/src/observable/from.rs
+++ b/src/observable/from.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use observable::ObservableFromFn;
 
 /// Creates an observable that produces values from an iterator.
 ///
@@ -30,13 +31,13 @@ use crate::prelude::*;
 ///
 pub fn from_iter<O, U, Iter, I>(
   iter: Iter,
-) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone, I, ()>
+) -> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, I, ()>
 where
   O: Observer<I, ()>,
   U: SubscriptionLike,
   Iter: IntoIterator<Item = I> + Clone,
 {
-  Observable::new(move |mut subscriber| {
+  observable::new(move |mut subscriber| {
     for v in iter.into_iter() {
       if !subscriber.is_closed() {
         subscriber.next(v);
@@ -69,13 +70,13 @@ where
 ///
 pub fn of<O, U, Item>(
   v: Item,
-) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
+) -> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
 where
   O: Observer<Item, ()>,
   U: SubscriptionLike,
   Item: Clone,
 {
-  Observable::new(move |mut subscriber| {
+  observable::new(move |mut subscriber| {
     subscriber.next(v);
     subscriber.complete();
   })
@@ -107,7 +108,7 @@ where
 pub fn repeat<O, U, Item>(
   v: Item,
   n: usize,
-) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
+) -> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
 where
   O: Observer<Item, ()>,
   U: SubscriptionLike,
@@ -142,14 +143,14 @@ where
 ///
 pub fn of_result<O, U, Item, Err>(
   r: Result<Item, Err>,
-) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone, Item, Err>
+) -> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, Item, Err>
 where
   O: Observer<Item, Err>,
   U: SubscriptionLike,
   Item: Clone,
   Err: Clone,
 {
-  Observable::new(move |mut subscriber| {
+  observable::new(move |mut subscriber| {
     match r {
       Ok(v) => subscriber.next(v),
       Err(e) => subscriber.error(e),
@@ -178,13 +179,13 @@ where
 ///
 pub fn of_option<O, U, Item>(
   o: Option<Item>,
-) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
+) -> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
 where
   O: Observer<Item, ()>,
   U: SubscriptionLike,
   Item: Clone,
 {
-  Observable::new(move |mut subscriber| {
+  observable::new(move |mut subscriber| {
     if let Some(v) = o {
       subscriber.next(v)
     }
@@ -211,7 +212,7 @@ where
 ///
 pub fn from_fn<O, U, Callable, Item>(
   f: Callable,
-) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
+) -> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
 where
   Callable: FnOnce() -> Item,
   O: Observer<Item, ()>,

--- a/src/observable/from.rs
+++ b/src/observable/from.rs
@@ -37,7 +37,7 @@ where
   U: SubscriptionLike,
   Iter: IntoIterator<Item = I> + Clone,
 {
-  observable::new(move |mut subscriber| {
+  observable::create(move |mut subscriber| {
     for v in iter.into_iter() {
       if !subscriber.is_closed() {
         subscriber.next(v);
@@ -76,7 +76,7 @@ where
   U: SubscriptionLike,
   Item: Clone,
 {
-  observable::new(move |mut subscriber| {
+  observable::create(move |mut subscriber| {
     subscriber.next(v);
     subscriber.complete();
   })
@@ -150,7 +150,7 @@ where
   Item: Clone,
   Err: Clone,
 {
-  observable::new(move |mut subscriber| {
+  observable::create(move |mut subscriber| {
     match r {
       Ok(v) => subscriber.next(v),
       Err(e) => subscriber.error(e),
@@ -185,7 +185,7 @@ where
   U: SubscriptionLike,
   Item: Clone,
 {
-  observable::new(move |mut subscriber| {
+  observable::create(move |mut subscriber| {
     if let Some(v) = o {
       subscriber.next(v)
     }

--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -42,7 +42,7 @@ where
   U: SubscriptionLike + Send + 'static,
   F: Future<Output = Item> + Send + Clone + Sync + 'static,
 {
-  observable::new(move |mut subscriber| {
+  observable::create(move |mut subscriber| {
     let fmapped = f.map(move |v| {
       if !subscriber.is_closed() {
         subscriber.next(v);
@@ -70,7 +70,7 @@ where
   F: Future + Send + Clone + Sync + 'static,
   <F as Future>::Output: Into<Result<Item, Error>>,
 {
-  observable::new(move |mut subscriber| {
+  observable::create(move |mut subscriber| {
     let fmapped = f.map(move |v| {
       if !subscriber.is_closed() {
         match v.into() {

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -5,6 +5,7 @@ use crate::prelude::*;
 use futures::prelude::*;
 use futures::{future::RemoteHandle, task::SpawnExt};
 use futures_timer::Interval;
+use observable::ObservableFromFn;
 use std::time::{Duration, Instant};
 
 /// Creates an observable which will fire at `dur` time into the future,
@@ -34,7 +35,7 @@ where
   interval_observable_impl(move || Interval::new_at(at, dur))
 }
 
-pub type IntervalOp<F, Err> = SharedOp<Observable<F, usize, Err>>;
+pub type IntervalOp<F, Err> = SharedOp<ObservableFromFn<F, usize, Err>>;
 pub trait IntervalFnOnce<O> = FnOnce(Subscriber<O, SharedSubscription>) + Clone;
 
 fn interval_observable_impl<O, Err>(
@@ -44,7 +45,7 @@ where
   O: Observer<usize, Err> + Send + Sync + 'static,
   Err: 'static,
 {
-  Observable::new(move |mut subscriber: Subscriber<O, SharedSubscription>| {
+  observable::new(move |mut subscriber: Subscriber<O, SharedSubscription>| {
     let mut subscription = subscriber.subscription.clone();
     let mut number = 0;
     let f = build_interval().for_each(move |_| {

--- a/src/observable/trivial.rs
+++ b/src/observable/trivial.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use observable::ObservableFromFn;
 
 /// Creates an observable that emitts no items, just terminates with an error.
 ///
@@ -8,14 +9,14 @@ use crate::prelude::*;
 ///
 pub fn throw<O, U, Item, Err>(
   e: Err,
-) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone, Item, Err>
+) -> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, Item, Err>
 where
   O: Observer<Item, Err>,
   U: SubscriptionLike,
   Err: Clone,
   Item: Clone,
 {
-  Observable::new(move |mut subscriber| {
+  observable::new(move |mut subscriber| {
     subscriber.error(e);
   })
 }
@@ -35,12 +36,12 @@ where
 /// ```
 ///
 pub fn empty<O, U, Item>()
--> Observable<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
+-> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
 where
   O: Observer<Item, ()>,
   U: SubscriptionLike,
 {
-  Observable::new(move |mut subscriber: Subscriber<O, U>| {
+  observable::new(move |mut subscriber: Subscriber<O, U>| {
     subscriber.complete();
   })
 }
@@ -50,12 +51,12 @@ where
 /// Neither emitts a value, nor completes, nor emitts an error.
 ///
 pub fn never<O, U, Item>()
--> Observable<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
+-> ObservableFromFn<impl FnOnce(Subscriber<O, U>) + Clone, Item, ()>
 where
   O: Observer<Item, ()>,
   U: SubscriptionLike,
 {
-  Observable::new(move |_subscriber: Subscriber<O, U>| {
+  observable::new(move |_subscriber: Subscriber<O, U>| {
     loop {
       // will not complete
       std::thread::sleep(std::time::Duration::from_secs(1));

--- a/src/observable/trivial.rs
+++ b/src/observable/trivial.rs
@@ -16,7 +16,7 @@ where
   Err: Clone,
   Item: Clone,
 {
-  observable::new(move |mut subscriber| {
+  observable::create(move |mut subscriber| {
     subscriber.error(e);
   })
 }
@@ -41,7 +41,7 @@ where
   O: Observer<Item, ()>,
   U: SubscriptionLike,
 {
-  observable::new(move |mut subscriber: Subscriber<O, U>| {
+  observable::create(move |mut subscriber: Subscriber<O, U>| {
     subscriber.complete();
   })
 }
@@ -56,7 +56,7 @@ where
   O: Observer<Item, ()>,
   U: SubscriptionLike,
 {
-  observable::new(move |_subscriber: Subscriber<O, U>| {
+  observable::create(move |_subscriber: Subscriber<O, U>| {
     loop {
       // will not complete
       std::thread::sleep(std::time::Duration::from_secs(1));

--- a/src/ops/first.rs
+++ b/src/ops/first.rs
@@ -182,7 +182,7 @@ mod test {
   fn first_or_support_fork() {
     let mut default = 0;
     let mut default2 = 0;
-    let o = Observable::new(|mut subscriber| {
+    let o = observable::new(|mut subscriber| {
       subscriber.complete();
     })
     .first_or(100);

--- a/src/ops/first.rs
+++ b/src/ops/first.rs
@@ -182,7 +182,7 @@ mod test {
   fn first_or_support_fork() {
     let mut default = 0;
     let mut default2 = 0;
-    let o = observable::new(|mut subscriber| {
+    let o = observable::create(|mut subscriber| {
       subscriber.complete();
     })
     .first_or(100);

--- a/src/ops/last.rs
+++ b/src/ops/last.rs
@@ -255,7 +255,7 @@ mod test {
   fn last_or_support_fork() {
     let mut default = 0;
     let mut default2 = 0;
-    let o = observable::new(|mut subscriber| {
+    let o = observable::create(|mut subscriber| {
       subscriber.complete();
     })
     .last_or(100);

--- a/src/ops/last.rs
+++ b/src/ops/last.rs
@@ -255,7 +255,7 @@ mod test {
   fn last_or_support_fork() {
     let mut default = 0;
     let mut default2 = 0;
-    let o = Observable::new(|mut subscriber| {
+    let o = observable::new(|mut subscriber| {
       subscriber.complete();
     })
     .last_or(100);

--- a/src/ops/merge.rs
+++ b/src/ops/merge.rs
@@ -325,7 +325,7 @@ mod test {
 
   #[test]
   fn merge_fork() {
-    let o = Observable::new(|mut s| {
+    let o = observable::new(|mut s| {
       s.next(1);
       s.next(2);
       s.error(());

--- a/src/ops/merge.rs
+++ b/src/ops/merge.rs
@@ -325,7 +325,7 @@ mod test {
 
   #[test]
   fn merge_fork() {
-    let o = observable::new(|mut s| {
+    let o = observable::create(|mut s| {
       s.next(1);
       s.next(2);
       s.error(());

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -154,7 +154,7 @@ mod test {
     let emit_thread = Arc::new(Mutex::new(id));
     let observe_thread = Arc::new(Mutex::new(vec![]));
     let oc = observe_thread.clone();
-    Observable::new(|mut s| {
+    observable::new(|mut s| {
       s.next(&1);
       s.next(&1);
       *emit_thread.lock().unwrap() = thread::current().id();

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -154,7 +154,7 @@ mod test {
     let emit_thread = Arc::new(Mutex::new(id));
     let observe_thread = Arc::new(Mutex::new(vec![]));
     let oc = observe_thread.clone();
-    observable::new(|mut s| {
+    observable::create(|mut s| {
       s.next(&1);
       s.next(&1);
       *emit_thread.lock().unwrap() = thread::current().id();

--- a/src/subscribable/subscribable_all.rs
+++ b/src/subscribable/subscribable_all.rs
@@ -41,15 +41,7 @@ where
   E: FnMut(Err),
 {
   #[inline(always)]
-  default fn error(&mut self, err: Err) { (self.error)(err); }
-}
-
-impl<N, E, C, Err> ObserverError<&mut Err> for SubscribeAll<N, E, C>
-where
-  E: for<'r> FnMut(&'r mut Err),
-{
-  #[inline(always)]
-  fn error(&mut self, err: &mut Err) { (self.error)(err); }
+  fn error(&mut self, err: Err) { (self.error)(err); }
 }
 
 impl<N, E, C, Item> ObserverNext<Item> for SubscribeAll<N, E, C>
@@ -57,15 +49,7 @@ where
   N: FnMut(Item),
 {
   #[inline(always)]
-  default fn next(&mut self, value: Item) { (self.next)(value); }
-}
-
-impl<N, E, C, Item> ObserverNext<&mut Item> for SubscribeAll<N, E, C>
-where
-  N: for<'r> FnMut(&'r mut Item),
-{
-  #[inline(always)]
-  fn next(&mut self, value: &mut Item) { (self.next)(value); }
+  fn next(&mut self, value: Item) { (self.next)(value); }
 }
 
 pub trait SubscribableAll<N, E, C> {

--- a/src/subscribable/subscribable_comp.rs
+++ b/src/subscribable/subscribable_comp.rs
@@ -25,15 +25,7 @@ where
   N: FnMut(Item),
 {
   #[inline(always)]
-  default fn next(&mut self, value: Item) { (self.next)(value); }
-}
-
-impl<N, C, Item> ObserverNext<&mut Item> for SubscribeComplete<N, C>
-where
-  N: for<'r> FnMut(&'r mut Item),
-{
-  #[inline(always)]
-  fn next(&mut self, value: &mut Item) { (self.next)(value); }
+  fn next(&mut self, value: Item) { (self.next)(value); }
 }
 
 impl<N, C> SubscribeComplete<N, C> {

--- a/src/subscribable/subscribable_err.rs
+++ b/src/subscribable/subscribable_err.rs
@@ -17,15 +17,7 @@ where
   N: FnMut(Item),
 {
   #[inline(always)]
-  default fn next(&mut self, err: Item) { (self.next)(err); }
-}
-
-impl<N, E, Item> ObserverNext<&mut Item> for SubscribeErr<N, E>
-where
-  N: for<'r> FnMut(&'r mut Item),
-{
-  #[inline(always)]
-  fn next(&mut self, value: &mut Item) { (self.next)(value); }
+  fn next(&mut self, err: Item) { (self.next)(err); }
 }
 
 impl<N, E, Err> ObserverError<Err> for SubscribeErr<N, E>
@@ -33,15 +25,7 @@ where
   E: FnMut(Err),
 {
   #[inline(always)]
-  default fn error(&mut self, err: Err) { (self.error)(err); }
-}
-
-impl<N, E, Err> ObserverError<&mut Err> for SubscribeErr<N, E>
-where
-  E: for<'r> FnMut(&'r mut Err),
-{
-  #[inline(always)]
-  fn error(&mut self, err: &mut Err) { (self.error)(err); }
+  fn error(&mut self, err: Err) { (self.error)(err); }
 }
 
 impl<N, E> SubscribeErr<N, E> {

--- a/src/subscribable/subscribable_pure.rs
+++ b/src/subscribable/subscribable_pure.rs
@@ -19,14 +19,7 @@ where
   N: FnMut(Item),
 {
   #[inline(always)]
-  default fn next(&mut self, value: Item) { (self.0)(value); }
-}
-
-impl<Item, N> ObserverNext<&mut Item> for SubscribePure<N>
-where
-  N: for<'r> FnMut(&'r mut Item),
-{
-  fn next(&mut self, value: &mut Item) { (self.0)(value); }
+  fn next(&mut self, value: Item) { (self.0)(value); }
 }
 
 impl<N> IntoShared for SubscribePure<N>

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -179,21 +179,6 @@ impl<'a> SubscriptionLike for Box<dyn SubscriptionLike + 'a> {
 impl<'a, Item, Err> SubscriptionLike for Box<dyn Publisher<Item, Err> + 'a> {
   subscription_direct_impl_proxy!();
 }
-impl<'a, Item, Err> SubscriptionLike
-  for Box<dyn for<'r> Publisher<&'r mut Item, Err> + 'a>
-{
-  subscription_direct_impl_proxy!();
-}
-impl<'a, Item, Err> SubscriptionLike
-  for Box<dyn for<'r> Publisher<Item, &'r mut Err> + 'a>
-{
-  subscription_direct_impl_proxy!();
-}
-impl<'a, Item, Err> SubscriptionLike
-  for Box<dyn for<'r> Publisher<&'r mut Item, &'r mut Err> + 'a>
-{
-  subscription_direct_impl_proxy!();
-}
 
 impl SubscriptionLike for Box<dyn SubscriptionLike + Send + Sync> {
   subscription_direct_impl_proxy!();


### PR DESCRIPTION
1. Rename Observable to ObservableFromFn
2. Remove `Observable::new`, and add a same `new` function in `observable` mod to replace it