### PR TITLE
feat: SubscriptionGuard has the #must_use attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased](https://github.com/rxRust/rxRust/compare/v0.8.1...HEAD)
 
+- **subscription** The guard returned by `unsubscribe_when_dropped()` has the [must_use](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute) attribute
+
 ## [0.8.1](https://github.com/rxRust/rxRust/releases/tag/v0.8.1)  (2020-02-28)
 
 - **docs**: fix docs link and remove inner macro from docs.

--- a/src/observable/observable_all.rs
+++ b/src/observable/observable_all.rs
@@ -107,10 +107,12 @@ fn raii() {
   let mut times = 0;
   {
     let mut subject = Subject::new();
-    subject
-      .clone()
-      .subscribe_all(|_| times += 1, |_| {}, || {})
-      .unsubscribe_when_dropped();
+    {
+      let _ = subject
+        .clone()
+        .subscribe_all(|_| times += 1, |_| {}, || {})
+        .unsubscribe_when_dropped();
+    } // <-- guard is dropped here!
     subject.next(());
     subject.error(());
   }

--- a/src/observable/observable_comp.rs
+++ b/src/observable/observable_comp.rs
@@ -85,10 +85,12 @@ fn raii() {
   let mut times = 0;
   {
     let mut subject = Subject::new();
-    subject
-      .clone()
-      .subscribe_complete(|_| times += 1, || {})
-      .unsubscribe_when_dropped();
+    {
+      let _ = subject
+        .clone()
+        .subscribe_complete(|_| times += 1, || {})
+        .unsubscribe_when_dropped();
+    } // <-- guard is dropped here!
     subject.next(());
   }
   assert_eq!(times, 0);

--- a/src/observable/observable_err.rs
+++ b/src/observable/observable_err.rs
@@ -78,10 +78,12 @@ fn raii() {
   let mut times = 0;
   {
     let mut subject = Subject::new();
-    subject
-      .clone()
-      .subscribe_err(|_| times += 1, |_| {})
-      .unsubscribe_when_dropped();
+    {
+      let _ = subject
+        .clone()
+        .subscribe_err(|_| times += 1, |_| {})
+        .unsubscribe_when_dropped();
+    } // <-- guard is dropped here!
     subject.next(());
     subject.error(());
   }

--- a/src/observable/observable_next.rs
+++ b/src/observable/observable_next.rs
@@ -53,12 +53,14 @@ fn raii() {
   let mut times = 0;
   {
     let mut subject = Subject::new();
-    subject
-      .clone()
-      .subscribe(|_| {
-        times += 1;
-      })
-      .unsubscribe_when_dropped();
+    {
+      let _ = subject
+        .clone()
+        .subscribe(|_| {
+          times += 1;
+        })
+        .unsubscribe_when_dropped();
+    } // <-- guard is dropped here!
     subject.next(());
   }
   assert_eq!(times, 0);

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -218,6 +218,14 @@ subscription_proxy_impl!(SubscriptionWrapper<T>, { 0 }, T);
 /// An RAII implementation of a "scoped subscribed" of a subscription.
 /// When this structure is dropped (falls out of scope), the subscription will
 /// be unsubscribed.
+///
+/// Implements the [must_use](
+/// https://doc.rust-lang.org/reference/attributes/diagnostics.html
+/// #the-must_use-attribute)
+/// attribute
+///
+/// If you want to drop it immediately, wrap it in it's own scope
+#[must_use]
 pub struct SubscriptionGuard<T: SubscriptionLike>(pub(crate) T);
 impl<T: SubscriptionLike> Drop for SubscriptionGuard<T> {
   #[inline]


### PR DESCRIPTION
Hi,

I added the [must_use](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute) attribute to the SubscriptionGuard.

This makes sure you don't forget to assign it to sth. after a call to `unsubscribe_when_dropped`.

Example compiler warning if you forget:
```
warning: unused subscription::SubscriptionGuard that must be used
   --> src/observable/observable_all.rs:117:7
    |
117 | /       subject
118 | |         .clone()
119 | |         .subscribe_all(|_| times += 1, |_| {}, || {})
120 | |         .unsubscribe_when_dropped();
    | |____________________________________^
    |
    = note: #[warn(unused_must_use)] on by default

    Finished test [unoptimized + debuginfo] target(s) in 7.73s
     Running `target/debug/deps/rxrust-78871ff7dfcfd963`
```
The warning disappears once you use it:
```
let _ = subject
    .clone()
    .subscribe_all(|_| times += 1, |_| {}, || {})
    .unsubscribe_when_dropped();
```

Default is for the compiler to warn, but user can set it to trigger an error. I think this should hence be handled as a breaking change.

