### PR TITLE
Relax Copy bound, introduce PayloadCopy instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **subscription** The guard returned by `unsubscribe_when_dropped()` has the [must_use](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute) attribute
 - **operator**: add `zip` operator.
 - **operator**: add `take_until` operator.
+- **observer**: add support for items/errors that don't implement `Copy` (by implementing `PayloadCopy`) 
 
 ## [0.8.1](https://github.com/rxRust/rxRust/releases/tag/v0.8.1)  (2020-02-28)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,6 @@ pub mod prelude {
   pub use crate::subscriber::Subscriber;
   pub use crate::subscription;
   pub use crate::subscription::*;
-  pub use observer::Observer;
+  pub use observer::{Observer, PayloadCopy};
   pub use shared::*;
 }

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -548,13 +548,14 @@ pub trait Observable {
   fn max(self) -> MinMaxOp<Self, Self::Item>
   where
     Self: Sized,
-    Self::Item: Copy + Send + PartialOrd<Self::Item>,
+    Self::Item: PayloadCopy + Send + PartialOrd<Self::Item>,
   {
     fn get_greater<Item>(i: Option<Item>, v: Item) -> Option<Item>
     where
-      Item: Copy + PartialOrd<Item>,
+      Item: PayloadCopy + PartialOrd<Item>,
     {
-      i.map(|vv| if vv < v { v } else { vv }).or(Some(v))
+      i.map(|vv| if vv < v { v.payload_copy() } else { vv })
+        .or(Some(v))
     }
     let get_greater_func =
       get_greater as fn(Option<Self::Item>, Self::Item) -> Option<Self::Item>;
@@ -586,13 +587,14 @@ pub trait Observable {
   fn min(self) -> MinMaxOp<Self, Self::Item>
   where
     Self: Sized,
-    Self::Item: Copy + Send + PartialOrd<Self::Item>,
+    Self::Item: PayloadCopy + Send + PartialOrd<Self::Item>,
   {
     fn get_lesser<Item>(i: Option<Item>, v: Item) -> Option<Item>
     where
-      Item: Copy + PartialOrd<Item>,
+      Item: PayloadCopy + PartialOrd<Item>,
     {
-      i.map(|vv| if vv > v { v } else { vv }).or(Some(v))
+      i.map(|vv| if vv > v { v.payload_copy() } else { vv })
+        .or(Some(v))
     }
 
     let get_lesser_func =
@@ -628,7 +630,7 @@ pub trait Observable {
   fn sum(self) -> SumOp<Self, Self::Item>
   where
     Self: Sized,
-    Self::Item: Copy + Default + Add<Self::Item, Output = Self::Item>,
+    Self::Item: PayloadCopy + Default + Add<Self::Item, Output = Self::Item>,
   {
     self.reduce(|acc, v| acc + v)
   }
@@ -682,7 +684,7 @@ pub trait Observable {
   fn average(self) -> AverageOp<Self, Self::Item>
   where
     Self: Sized,
-    Self::Item: Copy
+    Self::Item: PayloadCopy
       + Send
       + Default
       + Add<Self::Item, Output = Self::Item>
@@ -694,7 +696,7 @@ pub trait Observable {
     /// averaged (e.g. vectors)
     fn average_floats<T>(acc: Accum<T>) -> T
     where
-      T: Default + Copy + Send + Mul<f64, Output = T>,
+      T: Default + PayloadCopy + Send + Mul<f64, Output = T>,
     {
       // Note: we will never be dividing by zero here, as
       // the acc.1 will be always >= 1.
@@ -707,7 +709,7 @@ pub trait Observable {
 
     fn accumulate_item<T>(acc: Accum<T>, v: T) -> Accum<T>
     where
-      T: Copy + Add<T, Output = T>,
+      T: PayloadCopy + Add<T, Output = T>,
     {
       let newacc = acc.0 + v;
       let newcount = acc.1 + 1;

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -66,8 +66,8 @@ impl<Source, Subject> ConnectableObservable<Source, Subject> {
 impl<'a, S, Item, Err> LocalConnectableObservable<'a, S, Item, Err>
 where
   S: LocalObservable<'a, Item = Item, Err = Err>,
-  Item: Copy + 'a,
-  Err: Copy + 'a,
+  Item: PayloadCopy + 'a,
+  Err: PayloadCopy + 'a,
 {
   pub fn connect(self) -> S::Unsub {
     self.source.actual_subscribe(Subscriber {
@@ -80,8 +80,8 @@ where
 impl<S, Item, Err> SharedConnectableObservable<S, Item, Err>
 where
   S: SharedObservable<Item = Item, Err = Err>,
-  Item: Copy + Send + Sync + 'static,
-  Err: Copy + Send + Sync + 'static,
+  Item: PayloadCopy + Send + Sync + 'static,
+  Err: PayloadCopy + Send + Sync + 'static,
 {
   pub fn connect(self) -> S::Unsub {
     self.source.actual_subscribe(Subscriber {

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -150,19 +150,22 @@ where
 /// when you use subjects or cloned observables. All items/errors which are
 /// copyable (= implement `Copy`) work in such situations out of the box.
 /// Items/errors which implement just `Clone` but not `Copy` *don't* work out of
-/// the box (because rxRust wants to prevent you from
-/// accidentally introducing poorly performing observable chains). If you have
-/// such items/errors, you might want to implement `PayloadCopy` for them. You
-/// can use it just like a marker trait because there's a default method
-/// definition which simply calls `clone()` to make the copy.
+/// the box (because rxRust wants to prevent you from accidentally introducing
+/// poorly performing observable chains). If you have such items/errors, you
+/// might want to implement `PayloadCopy` for them. You can use it just like a
+/// marker trait because there's a default method definition which simply calls
+/// `clone()` to make the copy. However, take care to only implement it for
+/// types that are cheap to clone! In multi-observer scenarios (e.g. when using
+/// subjects), `payload_copy()` will be called for each single observer!
 ///
 /// # Example
 /// ```rust
 /// use rxrust::prelude::*;
+/// use std::rc::Rc;
 ///
 /// #[derive(Clone)]
 /// struct MyCloneableItem {
-///   text: String,
+///   text: Rc<String>,
 /// }
 ///
 /// impl PayloadCopy for MyCloneableItem {}
@@ -170,8 +173,7 @@ where
 pub trait PayloadCopy: Clone {
   /// Should return a copy of the value. Unlike `Copy`, this can be more than
   /// just a bitwise copy. Unlike `Clone`, this should still be a cheap
-  /// operation. In multi-observer scenarios (e.g. when using subjects) it
-  /// will be called for each single observer!
+  /// operation.
   #[must_use]
   fn payload_copy(&self) -> Self { self.clone() }
 }

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -123,18 +123,20 @@ observer_proxy_impl!(Rc<RefCell<S>>, { borrow_mut() }, Item, Err, S);
 impl<Item, Err, T> Observer<Item, Err> for Vec<T>
 where
   T: Publisher<Item, Err>,
-  Item: Copy,
-  Err: Copy,
+  Item: PayloadCopy,
+  Err: PayloadCopy,
 {
   fn next(&mut self, value: Item) {
     self.drain_filter(|subscriber| {
-      subscriber.next(value);
+      subscriber.next(value.payload_copy());
       subscriber.is_closed()
     });
   }
 
   fn error(&mut self, err: Err) {
-    self.iter_mut().for_each(|subscriber| subscriber.error(err));
+    self
+      .iter_mut()
+      .for_each(|subscriber| subscriber.error(err.payload_copy()));
     self.clear();
   }
 
@@ -143,3 +145,36 @@ where
     self.clear();
   }
 }
+
+/// There are situations in which rxRust needs to copy items/errors, for example
+/// when you use subjects or cloned observables. All items/errors which are
+/// copyable (= implement `Copy`) work in such situations out of the box.
+/// Items/errors which implement just `Clone` but not `Copy` *don't* work out of
+/// the box (because rxRust wants to prevent you from
+/// accidentally introducing poorly performing observable chains). If you have
+/// such items/errors, you might want to implement `PayloadCopy` for them. You
+/// can use it just like a marker trait because there's a default method
+/// definition which simply calls `clone()` to make the copy.
+///
+/// # Example
+/// ```rust
+/// use rxrust::prelude::*;
+///
+/// #[derive(Clone)]
+/// struct MyCloneableItem {
+///   text: String,
+/// }
+///
+/// impl PayloadCopy for MyCloneableItem {}
+/// ```
+pub trait PayloadCopy: Clone {
+  /// Should return a copy of the value. Unlike `Copy`, this can be more than
+  /// just a bitwise copy. Unlike `Clone`, this should still be a cheap
+  /// operation. In multi-observer scenarios (e.g. when using subjects) it
+  /// will be called for each single observer!
+  #[must_use]
+  fn payload_copy(&self) -> Self { self.clone() }
+}
+
+// Support all copyable types by default
+impl<T: Copy> PayloadCopy for T {}

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -102,8 +102,8 @@ impl<'a, Item, Err, S> LocalObservable<'a> for LocalRefCount<'a, S, Item, Err>
 where
   S: LocalObservable<'a, Item = Item, Err = Err> + Clone,
   S::Unsub: Clone,
-  Item: Copy + 'a,
-  Err: Copy + 'a,
+  Item: PayloadCopy + 'a,
+  Err: PayloadCopy + 'a,
 {
   type Unsub = RefCountSubscription<LocalSubscription, S::Unsub>;
   fn actual_subscribe<O: Observer<Self::Item, Self::Err> + 'a>(
@@ -135,8 +135,8 @@ impl<Item, Err, S> SharedObservable for SharedRefCount<S, Item, Err>
 where
   S: SharedObservable<Item = Item, Err = Err> + Clone,
   S::Unsub: Clone,
-  Item: Copy + Send + Sync + 'static,
-  Err: Copy + Send + Sync + 'static,
+  Item: PayloadCopy + Send + Sync + 'static,
+  Err: PayloadCopy + Send + Sync + 'static,
 {
   type Unsub = RefCountSubscription<SharedSubscription, S::Unsub>;
   fn actual_subscribe<

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -27,7 +27,7 @@ where
 
 subscription_proxy_impl!(Subject<O, U>, {subscription}, U, <O>);
 observer_proxy_impl!(
-  Subject<O, U>, {observers}, Item, Err, O, <U>, {where Item: Copy, Err: Copy});
+  Subject<O, U>, {observers}, Item, Err, O, <U>, {where Item: PayloadCopy, Err: PayloadCopy});
 
 #[cfg(test)]
 mod test {

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -26,8 +26,8 @@ where
 }
 
 subscription_proxy_impl!(Subject<O, U>, {subscription}, U, <O>);
-observer_proxy_impl!(
-  Subject<O, U>, {observers}, Item, Err, O, <U>, {where Item: PayloadCopy, Err: PayloadCopy});
+observer_proxy_impl!(Subject<O, U>, {observers}, Item, Err, O, <U>, 
+  {where Item: PayloadCopy, Err: PayloadCopy});
 
 #[cfg(test)]
 mod test {

--- a/src/subject/mut_ref_subject.rs
+++ b/src/subject/mut_ref_subject.rs
@@ -78,7 +78,7 @@ impl<'a, Item, Err> LocalSubject<'a, MutRefValue<Item>, MutRefValue<Err>> {
   }
 }
 
-impl<'a, Item, Err: Copy> Observer<&mut Item, Err>
+impl<'a, Item, Err: PayloadCopy> Observer<&mut Item, Err>
   for MutRefSubject<
     'a,
     MutRefValue<Item>,
@@ -93,7 +93,7 @@ impl<'a, Item, Err: Copy> Observer<&mut Item, Err>
   complete_proxy_impl!(subject);
 }
 
-impl<'a, Item: Copy, Err> Observer<Item, &mut Err>
+impl<'a, Item: PayloadCopy, Err> Observer<Item, &mut Err>
   for MutRefSubject<
     'a,
     Item,


### PR DESCRIPTION
This solves #74. 

Implementing `PayloadCopy` for built-in non-copyable types like `Rc` or `Cell` seems to be impossible (I think because `Copy` is not a fundamental type). That's not a big deal though because users can always create their own lightweight wrapper types (e.g. using newtype pattern).