### PR TITLE
Feat: Add of_sequence macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **operator**: add `take_while` operator.
 - **operator**: add `share` operator.
 - **observer**: add support for items/errors that don't implement `Copy` (by implementing `PayloadCopy`) 
+- **observable**: add macros `of_sequence` that producing values from a custom sequence. 
 
 ## [0.8.1](https://github.com/rxRust/rxRust/releases/tag/v0.8.1)  (2020-02-28)
 

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -5,7 +5,7 @@ mod from_iter;
 pub use from_iter::{from_iter, repeat};
 
 mod of;
-pub use of::{of, of_fn, of_option, of_result};
+pub use of::{of, of_fn, of_option, of_result, of_sequence};
 
 pub(crate) mod from_future;
 pub use from_future::{from_future, from_future_result};

--- a/src/observable/of.rs
+++ b/src/observable/of.rs
@@ -1,5 +1,37 @@
 use crate::prelude::*;
 
+/// Creates an observable producing a multiple values.
+///
+/// Completes immediately after emitting the values given. Never emits an error.
+///
+/// # Arguments
+///
+/// * `v` - A value to emits.
+///
+/// # Examples
+///
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::of_sequence!(1, 2, 3)
+///   .subscribe(|v| {println!("{},", v)});
+///
+/// // print log:
+/// // 1
+/// // 2
+/// // 3
+/// ```
+pub macro of_sequence( $( $item:expr ),* ) {
+  {
+    $crate::observable::create(|mut s| {
+      $(
+        s.next($item);
+      )*
+      s.complete();
+    })
+  }
+}
+
 /// Creates an observable producing a single value.
 ///
 /// Completes immediately after emitting the value given. Never emits an error.
@@ -296,5 +328,13 @@ mod test {
 
     assert_eq!(value, 100);
     assert_eq!(completed, true);
+  }
+
+  #[test]
+  fn of_macros() {
+    let mut value = 0;
+    observable::of_sequence!(1, 2, 3).subscribe(|v| value += v);
+
+    assert_eq!(value, 6);
   }
 }


### PR DESCRIPTION
Hey! With of_sequence will possibly create observable from custom sequences of values like:
```rust
of_sequence!(1, 2, 3)
```