### PR TITLE
fix: mark methods that to create a MutRefSubjet as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking Changes
 
 **operator**: add some explicit bounds on operators method to improve type infer, and some code use `map` may not compile, if it's just `map` and never subscribe. 
+**Subject**: MutRefSubject now mark as unsafe.
 
 ### Features
 - **subscription** The guard returned by `unsubscribe_when_dropped()` has the [must_use](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute) attribute

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -142,12 +142,14 @@ fn filter() {
   use crate::subject::MutRefValue;
   let mut subject = Subject::new();
 
-  subject
-    .clone()
-    .mut_ref_all()
-    .filter_map::<fn(&mut i32) -> Option<&mut i32>, _, _>(|v| Some(v))
-    .publish()
-    .subscribe_err(|_: &mut _| {}, |_: &mut i32| {});
+  unsafe {
+    subject
+      .clone()
+      .mut_ref_all()
+      .filter_map::<fn(&mut i32) -> Option<&mut i32>, _, _>(|v| Some(v))
+      .publish()
+      .subscribe_err(|_: &mut _| {}, |_: &mut i32| {});
+  }
 
   subject.next(MutRefValue(&mut 1));
   subject.error(MutRefValue(&mut 2));

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -143,7 +143,7 @@ mod test {
   }
   #[test]
   fn filter_map_mut_ref() {
-    let mut subject = Subject::new().mut_ref_item();
+    let mut subject = unsafe { Subject::new().mut_ref_item() };
     subject
       .clone()
       .filter_map::<fn(&mut i32) -> Option<&mut i32>, _, _>(|v| Some(v))

--- a/src/subject/mut_ref_subject.rs
+++ b/src/subject/mut_ref_subject.rs
@@ -35,7 +35,10 @@ pub type MutRefItemSubject<'a, Item, Err> = MutRefSubject<
   fn(Err) -> Err,
 >;
 impl<'a, Item, Err> LocalSubject<'a, MutRefValue<Item>, Err> {
-  pub fn mut_ref_item(self) -> MutRefItemSubject<'a, Item, Err> {
+  /// # Safety
+  /// You should know MutRefSubject will be erased the life time of your mut
+  /// ref value.
+  pub unsafe fn mut_ref_item(self) -> MutRefItemSubject<'a, Item, Err> {
     MutRefSubject {
       subject: self,
       map_item: value_as_mut_ref,
@@ -52,7 +55,10 @@ pub type MutRefErrSubject<'a, Item, Err> = MutRefSubject<
   fn(MutRefValue<Err>) -> &'a mut Err,
 >;
 impl<'a, Item, Err> LocalSubject<'a, Item, MutRefValue<Err>> {
-  pub fn mut_ref_err(self) -> MutRefErrSubject<'a, Item, Err> {
+  /// # Safety
+  /// You should know MutRefSubject will be erased the life time of your mut ref
+  /// error.
+  pub unsafe fn mut_ref_err(self) -> MutRefErrSubject<'a, Item, Err> {
     MutRefSubject {
       subject: self,
       map_item: none_map,
@@ -69,7 +75,10 @@ pub type MutRefAllSubject<'a, Item, Err> = MutRefSubject<
   fn(MutRefValue<Item>) -> &'a mut Item,
 >;
 impl<'a, Item, Err> LocalSubject<'a, MutRefValue<Item>, MutRefValue<Err>> {
-  pub fn mut_ref_all(self) -> MutRefAllSubject<'a, Item, Err> {
+  /// # Safety
+  /// You should know MutRefSubject will be erased the life time of your mut ref
+  /// value and error.
+  pub unsafe fn mut_ref_all(self) -> MutRefAllSubject<'a, Item, Err> {
     MutRefSubject {
       subject: self,
       map_item: value_as_mut_ref,
@@ -178,7 +187,7 @@ where
 fn mut_ref_item() {
   let mut test_code = 0;
   {
-    let mut subject = Subject::new().mut_ref_item();
+    let mut subject = unsafe { Subject::new().mut_ref_item() };
     subject.clone().subscribe(|v: &mut i32| {
       *v = 100;
     });
@@ -191,7 +200,7 @@ fn mut_ref_item() {
 fn mut_ref_err() {
   let mut test_code = 0;
   {
-    let mut subject = Subject::new().mut_ref_err();
+    let mut subject = unsafe { Subject::new().mut_ref_err() };
     subject.clone().subscribe_err(
       |_: i32| {},
       |v: &mut i32| {


### PR DESCRIPTION
Becasuse the lifetime of mut ref will be erased.