### PR TITLE
refactor-rename-shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ### Features
 - **operator**: add `flatten` operator.
 
+### Breaking Changes
+
+- **SharedObservable**:  rename `SharedObservable::to_shared` as `SharedObservable::into_shared`
+
 ## [0.11.0](https://github.com/rxRust/rxRust/compare/v0.10.0...HEAD)
 ### Features
 - **operator**: add `element_at` operator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased](https://github.com/rxRust/rxRust/compare/v0.11.0...HEAD)
+### Features
+- **operator**: add `flatten` operator.
 
 ## [0.11.0](https://github.com/rxRust/rxRust/compare/v0.10.0...HEAD)
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 5. Make sure your code lints.
 6. Issue that pull request!
 
+## Commit Message
+
+we recommend use [git-cz](https://github.com/streamich/git-cz) to format your commit message.
+
 ## Any contributions you make will be under the MIT Software License
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ let pool_scheduler = ThreadPool::new().unwrap();
 observable::from_iter(0..10)
   .subscribe_on(pool_scheduler.clone())
   .map(|v| v*2)
-  .to_shared()
+  .into_shared()
   .observe_on(pool_scheduler)
-  .to_shared()
+  .into_shared()
   .subscribe(|v| {println!("{},", v)});
 ```
 

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1203,7 +1203,7 @@ mod tests {
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
     assert_eq!(next_count, 1);
-    assert_eq!(completed, true);
+    assert!(completed);
 
     completed = false;
     let mut v = 0;
@@ -1211,7 +1211,7 @@ mod tests {
       .first_or(100)
       .subscribe_complete(|value| v = value, || completed = true);
 
-    assert_eq!(completed, true);
+    assert!(completed);
     assert_eq!(v, 100);
   }
 

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1006,7 +1006,7 @@ pub trait Observable: Sized {
   /// let pool = ThreadPool::new().unwrap();
   /// let a = observable::from_iter(1..5).subscribe_on(pool);
   /// let b = observable::from_iter(5..10);
-  /// a.merge(b).to_shared().subscribe(|v|{
+  /// a.merge(b).into_shared().subscribe(|v|{
   ///   let handle = thread::current();
   ///   print!("{}({:?}) ", v, handle.id())
   /// });
@@ -1262,7 +1262,7 @@ mod tests {
   fn shared_ignore_elements() {
     observable::from_iter(0..20)
       .ignore_elements()
-      .to_shared()
+      .into_shared()
       .subscribe(|_| panic!());
   }
 

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -119,8 +119,8 @@ mod test {
   fn fork_and_shared() {
     let o = observable::of(100);
     let connected = ConnectableObservable::new(o);
-    connected.clone().to_shared().subscribe(|_| {});
-    connected.clone().to_shared().subscribe(|_| {});
+    connected.clone().into_shared().subscribe(|_| {});
+    connected.clone().into_shared().subscribe(|_| {});
 
     connected.connect();
   }

--- a/src/observable/from_fn.rs
+++ b/src/observable/from_fn.rs
@@ -88,7 +88,7 @@ mod test {
       subscriber.next(&3);
       subscriber.error("never dispatch error");
     })
-    .to_shared()
+    .into_shared()
     .subscribe_all(
       move |_| *next.lock().unwrap() += 1,
       move |_: &str| *err.lock().unwrap() += 1,
@@ -121,10 +121,10 @@ mod test {
   #[test]
   fn fork_and_share() {
     let observable = observable::create(|_| {});
-    observable.clone().to_shared().subscribe(|_: i32| {});
-    observable.clone().to_shared().subscribe(|_| {});
+    observable.clone().into_shared().subscribe(|_: i32| {});
+    observable.clone().into_shared().subscribe(|_| {});
 
-    let observable = observable::create(|_| {}).to_shared();
+    let observable = observable::create(|_| {}).into_shared();
     observable.clone().subscribe(|_: i32| {});
     observable.clone().subscribe(|_| {});
   }

--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -190,7 +190,7 @@ mod tests {
     let pool = ThreadPool::new().unwrap();
     {
       from_future_result(future::ok(1), pool.clone())
-        .to_shared()
+        .into_shared()
         .subscribe(move |v| {
           *res.lock().unwrap() = v;
         });
@@ -200,7 +200,7 @@ mod tests {
     // from_future
     let res = c_res.clone();
     from_future(future::ready(2), pool)
-      .to_shared()
+      .into_shared()
       .subscribe(move |v| {
         *res.lock().unwrap() = v;
       });

--- a/src/observable/from_iter.rs
+++ b/src/observable/from_iter.rs
@@ -124,7 +124,7 @@ mod test {
       .subscribe_complete(|_| hit_count += 1, || completed = true);
 
     assert_eq!(hit_count, 100);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]
@@ -135,7 +135,7 @@ mod test {
       .subscribe_complete(|_| hit_count += 1, || completed = true);
 
     assert_eq!(hit_count, 100);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -107,7 +107,7 @@ mod tests {
     let pool = ThreadPool::new().unwrap();
 
     interval(Duration::from_millis(10), pool)
-      .to_shared()
+      .into_shared()
       .subscribe(move |_| {
         *seconds.lock().unwrap() += 1;
       });

--- a/src/observable/of.rs
+++ b/src/observable/of.rs
@@ -329,7 +329,7 @@ mod test {
     observable::of(100).subscribe_complete(|v| value = v, || completed = true);
 
     assert_eq!(value, 100);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]

--- a/src/observable/trivial.rs
+++ b/src/observable/trivial.rs
@@ -140,6 +140,6 @@ mod test {
     observable::empty().subscribe_complete(|()| hits += 1, || completed = true);
 
     assert_eq!(hits, 0);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -130,8 +130,8 @@ mod test {
     // type to type can fork
     let m = observable::from_iter(0..100).reduce(|acc: i32, v| acc + v);
     m.reduce(|acc: i32, v| acc + v)
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
 
@@ -209,7 +209,7 @@ mod test {
   fn max_fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(vec![1., 2.]).max();
-    m.to_shared().to_shared().subscribe(|_| {});
+    m.into_shared().into_shared().subscribe(|_| {});
   }
 
   // -------------------------------------------------------------------
@@ -284,7 +284,7 @@ mod test {
   fn min_fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(vec![1., 2.]).min();
-    m.to_shared().to_shared().subscribe(|_| {});
+    m.into_shared().into_shared().subscribe(|_| {});
   }
 
   #[test]
@@ -323,7 +323,7 @@ mod test {
   fn sum_fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(0..100).sum();
-    m.sum().to_shared().to_shared().subscribe(|_| {});
+    m.sum().into_shared().into_shared().subscribe(|_| {});
   }
 
   #[test]
@@ -348,7 +348,7 @@ mod test {
   fn count_fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(0..100).count();
-    m.to_shared().to_shared().subscribe(|_| {});
+    m.into_shared().into_shared().subscribe(|_| {});
   }
 
   #[test]
@@ -424,6 +424,6 @@ mod test {
   fn average_fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(vec![1., 2.]).average();
-    m.to_shared().to_shared().subscribe(|_| {});
+    m.into_shared().into_shared().subscribe(|_| {});
   }
 }

--- a/src/ops/box_it.rs
+++ b/src/ops/box_it.rs
@@ -238,10 +238,10 @@ mod test {
   #[test]
   fn shared_box_observable() {
     let mut boxed: SharedBoxOp<i32, ()> = observable::of(100).box_it();
-    boxed.to_shared().subscribe(|_| {});
+    boxed.into_shared().subscribe(|_| {});
 
     boxed = observable::empty().box_it();
-    boxed.to_shared().subscribe(|_| unreachable!());
+    boxed.into_shared().subscribe(|_| unreachable!());
   }
 
   #[test]
@@ -257,7 +257,7 @@ mod test {
     observable::of(100)
       .box_it::<Box<dyn SharedBoxClone<Item = _, Err = _>>>()
       .clone()
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
 

--- a/src/ops/contains.rs
+++ b/src/ops/contains.rs
@@ -103,7 +103,7 @@ mod test {
   fn contains_shared() {
     observable::from_iter(0..10)
       .contains(4)
-      .to_shared()
+      .into_shared()
       .subscribe(|b| assert!(b));
   }
   #[bench]

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -219,8 +219,8 @@ mod tests {
     let scheduler = ThreadPool::new().unwrap();
     observable::from_iter(0..10)
       .debounce(Duration::from_nanos(1), scheduler)
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
 }

--- a/src/ops/default_if_empty.rs
+++ b/src/ops/default_if_empty.rs
@@ -116,18 +116,18 @@ mod test {
   }
 
   #[test]
-  fn into_shared() {
+  fn ininto_shared() {
     observable::from_iter(0..100)
       .default_if_empty(5)
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
 
   #[test]
-  fn into_shared_empty() {
+  fn ininto_shared_empty() {
     observable::empty()
       .default_if_empty(5)
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/default_if_empty.rs
+++ b/src/ops/default_if_empty.rs
@@ -99,7 +99,7 @@ mod test {
       .subscribe_complete(|v| value = v, || completed = true);
 
     assert_eq!(value, 10);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]
@@ -112,11 +112,11 @@ mod test {
       .subscribe_complete(|v| value = v, || completed = true);
 
     assert_eq!(value, 5);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]
-  fn ininto_shared() {
+  fn into_shared() {
     observable::from_iter(0..100)
       .default_if_empty(5)
       .into_shared()

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -78,7 +78,7 @@ mod tests {
     let pool = ThreadPool::new().unwrap();
     observable::of(1)
       .delay(Duration::from_millis(50), pool)
-      .to_shared()
+      .into_shared()
       .subscribe(move |v| {
         *value.lock().unwrap() = v;
       });

--- a/src/ops/distinct.rs
+++ b/src/ops/distinct.rs
@@ -89,8 +89,8 @@ mod tests {
   fn shared() {
     observable::from_iter(0..10)
       .distinct()
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -89,7 +89,7 @@ mod test {
       .clone()
       .filter(|_| true)
       .clone()
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
 

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -99,7 +99,7 @@ mod test {
     observable::of(1)
       .filter_map(|_| Some("str"))
       .clone()
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
 
@@ -108,7 +108,7 @@ mod test {
     observable::of(&1)
       .filter_map(Some)
       .clone()
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/finalize.rs
+++ b/src/ops/finalize.rs
@@ -255,9 +255,9 @@ mod test {
     let finalized_clone = finalized.clone();
     let mut subscription = s
       .clone()
-      .to_shared()
+      .into_shared()
       .finalize(move || finalized_clone.store(true, Ordering::Relaxed))
-      .to_shared()
+      .into_shared()
       .subscribe(|_| ());
     s.next(1);
     s.next(2);

--- a/src/ops/flatten.rs
+++ b/src/ops/flatten.rs
@@ -459,7 +459,7 @@ mod test {
     let local1 = observable::of(1);
     let local2 = observable::of(2);
 
-    let shared = source.clone().flatten().to_shared();
+    let shared = source.clone().flatten().into_shared();
 
     shared.subscribe(move |v: i32| {
       res.push(v);

--- a/src/ops/flatten.rs
+++ b/src/ops/flatten.rs
@@ -409,13 +409,13 @@ mod test {
     source.next(two.clone());
 
     one.complete();
-    assert_eq!(c_clone.load(Ordering::Relaxed), false);
+    assert!(!c_clone.load(Ordering::Relaxed));
 
     two.complete();
-    assert_eq!(c_clone.load(Ordering::Relaxed), false);
+    assert!(!c_clone.load(Ordering::Relaxed));
 
     source.complete();
-    assert_eq!(c_clone.load(Ordering::Relaxed), true);
+    assert!(c_clone.load(Ordering::Relaxed));
   }
 
   #[test]

--- a/src/ops/last.rs
+++ b/src/ops/last.rs
@@ -185,14 +185,14 @@ mod test {
   fn last_fork_and_shared() {
     observable::of(0)
       .last_or(0)
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
 
     observable::of(0)
       .last()
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -103,15 +103,15 @@ mod test {
   fn fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(0..100).map(|v| v);
-    m.map(|v| v).to_shared().subscribe(|_| {});
+    m.map(|v| v).into_shared().subscribe(|_| {});
 
     // type mapped to other type can fork
     let m = observable::from_iter(vec!['a', 'b', 'c']).map(|_v| 1);
-    m.map(|v| v as f32).to_shared().subscribe(|_| {});
+    m.map(|v| v as f32).into_shared().subscribe(|_| {});
 
     // ref to ref can fork
     let m = observable::of(&1).map(|v| v);
-    m.map(|v| v).to_shared().subscribe(|_| {});
+    m.map(|v| v).into_shared().subscribe(|_| {});
   }
 
   #[test]

--- a/src/ops/map_to.rs
+++ b/src/ops/map_to.rs
@@ -103,15 +103,15 @@ mod test {
   fn fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(0..100).map_to(5);
-    m.map_to(6).to_shared().subscribe(|_| {});
+    m.map_to(6).into_shared().subscribe(|_| {});
 
     // type mapped to other type can fork
     let m = observable::from_iter(vec!['a', 'b', 'c']).map_to(1);
-    m.map_to(2.0).to_shared().subscribe(|_| {});
+    m.map_to(2.0).into_shared().subscribe(|_| {});
 
     // ref to ref can fork
     let m = observable::of(&1).map_to(3);
-    m.map_to(4).to_shared().subscribe(|_| {});
+    m.map_to(4).into_shared().subscribe(|_| {});
   }
 
   #[test]

--- a/src/ops/merge.rs
+++ b/src/ops/merge.rs
@@ -183,12 +183,12 @@ mod test {
     );
 
     even.complete();
-    assert_eq!(c_clone.load(Ordering::Relaxed), false);
+    assert!(!c_clone.load(Ordering::Relaxed));
     odd.complete();
-    assert_eq!(c_clone.load(Ordering::Relaxed), true);
+    assert!(c_clone.load(Ordering::Relaxed));
     c_clone.store(false, Ordering::Relaxed);
     even.complete();
-    assert_eq!(c_clone.load(Ordering::Relaxed), false);
+    assert!(!c_clone.load(Ordering::Relaxed));
   }
 
   #[test]

--- a/src/ops/merge.rs
+++ b/src/ops/merge.rs
@@ -234,7 +234,7 @@ mod test {
     let shared = observable::of(1);
     let local = observable::of(2);
 
-    shared.merge(local).to_shared().subscribe(move |v| {
+    shared.merge(local).into_shared().subscribe(move |v| {
       res.push(v);
     });
   }

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -204,7 +204,7 @@ mod test {
       *emit_thread.lock().unwrap() = thread::current().id();
     })
     .observe_on(pool)
-    .to_shared()
+    .into_shared()
     .subscribe(move |_v| {
       observe_thread.lock().unwrap().push(thread::current().id());
     });
@@ -223,10 +223,10 @@ mod test {
     let emitted = Arc::new(Mutex::new(vec![]));
     let c_emitted = emitted.clone();
     observable::from_iter(0..10)
-      .to_shared()
+      .into_shared()
       .observe_on(scheduler.clone())
       .delay(Duration::from_millis(10), scheduler)
-      .to_shared()
+      .into_shared()
       .subscribe(move |v| {
         emitted.lock().unwrap().push(v);
       })

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -244,27 +244,27 @@ mod test {
     Subject::new()
       .publish()
       .ref_count()
-      .to_shared()
+      .into_shared()
       .subscribe(|_: i32| {});
 
     observable::of(1)
       .publish()
       .ref_count()
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
 
     observable::of(1)
-      .to_shared()
+      .into_shared()
       .publish()
       .ref_count()
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
     observable::of(1)
-      .to_shared()
+      .into_shared()
       .publish()
       .ref_count()
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/sample.rs
+++ b/src/ops/sample.rs
@@ -190,11 +190,11 @@ mod test {
     let x = Rc::new(RefCell::new(vec![]));
 
     let interval =
-      observable::interval(Duration::from_millis(2), pool.spawner());
+      observable::interval(Duration::from_millis(1), pool.spawner());
     {
       let x_c = x.clone();
       interval
-        .take(49)
+        .take(100)
         .sample(observable::interval(
           Duration::from_millis(10),
           pool.spawner(),

--- a/src/ops/sample.rs
+++ b/src/ops/sample.rs
@@ -216,7 +216,7 @@ mod test {
     subject
       .clone()
       .sample(notifier.clone())
-      .to_shared()
+      .into_shared()
       .subscribe(move |v: i32| {
         *c_test_code.lock().unwrap() = v;
       });

--- a/src/ops/scan.rs
+++ b/src/ops/scan.rs
@@ -157,8 +157,8 @@ mod test {
     // type to type can fork
     let m = observable::from_iter(vec!['a', 'b', 'c']).scan(|_acc, _v| 1i32);
     m.scan(|_acc, v| v as f32)
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
 
@@ -167,8 +167,8 @@ mod test {
     // type to type can fork
     let m = observable::from_iter(0..100).scan(|acc: i32, v| acc + v);
     m.scan(|acc: i32, v| acc + v)
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/skip.rs
+++ b/src/ops/skip.rs
@@ -94,7 +94,7 @@ mod test {
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
     assert_eq!(next_count, 95);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]
@@ -107,7 +107,7 @@ mod test {
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
     assert_eq!(next_count, 0);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]

--- a/src/ops/skip.rs
+++ b/src/ops/skip.rs
@@ -127,11 +127,11 @@ mod test {
   }
 
   #[test]
-  fn into_shared() {
+  fn ininto_shared() {
     observable::from_iter(0..100)
       .skip(5)
       .skip(5)
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/skip_last.rs
+++ b/src/ops/skip_last.rs
@@ -89,7 +89,7 @@ mod test {
       .subscribe_complete(|v| ticks.push(v), || completed = true);
 
     assert_eq!(ticks, vec![0, 1, 2, 3, 4]);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]
@@ -102,7 +102,7 @@ mod test {
       .subscribe_complete(|v| ticks.push(v), || completed = true);
 
     assert_eq!(ticks, vec![]);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]

--- a/src/ops/skip_last.rs
+++ b/src/ops/skip_last.rs
@@ -122,11 +122,11 @@ mod test {
   }
 
   #[test]
-  fn into_shared() {
+  fn ininto_shared() {
     observable::from_iter(0..100)
       .skip_last(5)
       .skip_last(5)
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/skip_while.rs
+++ b/src/ops/skip_while.rs
@@ -113,11 +113,11 @@ mod test {
   }
 
   #[test]
-  fn into_shared() {
+  fn ininto_shared() {
     observable::from_iter(0..100)
       .skip_while(|v| v < &95)
       .skip_while(|v| v < &95)
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/skip_while.rs
+++ b/src/ops/skip_while.rs
@@ -93,7 +93,7 @@ mod test {
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
     assert_eq!(next_count, 5);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]

--- a/src/ops/subscribe_on.rs
+++ b/src/ops/subscribe_on.rs
@@ -82,7 +82,7 @@ mod test {
     let c_thread = thread.clone();
     observable::from_iter(1..5)
       .subscribe_on(pool)
-      .to_shared()
+      .into_shared()
       .subscribe(move |v| {
         res.lock().unwrap().push(v);
         let handle = thread::current();
@@ -102,7 +102,7 @@ mod test {
     observable::from_iter(0..10)
       .subscribe_on(pool.clone())
       .delay(Duration::from_millis(10), pool)
-      .to_shared()
+      .into_shared()
       .subscribe(move |v| {
         emitted.lock().unwrap().push(v);
       })

--- a/src/ops/take.rs
+++ b/src/ops/take.rs
@@ -113,11 +113,11 @@ mod test {
   }
 
   #[test]
-  fn into_shared() {
+  fn ininto_shared() {
     observable::from_iter(0..100)
       .take(5)
       .take(5)
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/take.rs
+++ b/src/ops/take.rs
@@ -93,7 +93,7 @@ mod test {
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
     assert_eq!(next_count, 5);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]

--- a/src/ops/take_last.rs
+++ b/src/ops/take_last.rs
@@ -112,11 +112,11 @@ mod test {
   }
 
   #[test]
-  fn into_shared() {
+  fn ininto_shared() {
     observable::from_iter(0..100)
       .take_last(5)
       .take_last(5)
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/take_last.rs
+++ b/src/ops/take_last.rs
@@ -92,7 +92,7 @@ mod test {
       .subscribe_complete(|v| ticks.push(v), || completed = true);
 
     assert_eq!(ticks, vec![95, 96, 97, 98, 99]);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]

--- a/src/ops/take_until.rs
+++ b/src/ops/take_until.rs
@@ -145,7 +145,7 @@ mod test {
   }
 
   #[test]
-  fn into_shared() {
+  fn ininto_shared() {
     let last_next_arg = Arc::new(Mutex::new(None));
     let last_next_arg_mirror = last_next_arg.clone();
     let next_count = Arc::new(Mutex::new(0));
@@ -157,7 +157,7 @@ mod test {
     source
       .clone()
       .take_until(notifier.clone())
-      .to_shared()
+      .into_shared()
       .subscribe_complete(
         move |i| {
           *last_next_arg.lock().unwrap() = Some(i);

--- a/src/ops/take_while.rs
+++ b/src/ops/take_while.rs
@@ -119,11 +119,11 @@ mod test {
   }
 
   #[test]
-  fn into_shared() {
+  fn ininto_shared() {
     observable::from_iter(0..100)
       .take_while(|v| v < &5)
       .take_while(|v| v < &5)
-      .to_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
   #[bench]

--- a/src/ops/take_while.rs
+++ b/src/ops/take_while.rs
@@ -99,7 +99,7 @@ mod test {
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
     assert_eq!(next_count, 5);
-    assert_eq!(completed, true);
+    assert!(completed);
   }
 
   #[test]

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -235,8 +235,8 @@ mod tests {
     let scheduler = ThreadPool::new().unwrap();
     observable::from_iter(0..10)
       .throttle_time(Duration::from_nanos(1), ThrottleEdge::Leading, scheduler)
-      .to_shared()
-      .to_shared()
+      .into_shared()
+      .into_shared()
       .subscribe(|_| {});
   }
 }

--- a/src/ops/zip.rs
+++ b/src/ops/zip.rs
@@ -216,7 +216,7 @@ mod test {
 
       s1.complete();
     }
-    assert_eq!(complete, false);
+    assert!(!complete);
 
     {
       let mut s1 = Subject::new();
@@ -228,7 +228,7 @@ mod test {
       s1.complete();
       s2.complete();
     }
-    assert_eq!(complete, true);
+    assert!(complete);
   }
   #[bench]
   fn bench_zip(b: &mut Bencher) { b.iter(smoke); }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -151,7 +151,7 @@ mod test {
       observable::from_iter(0..1000)
         .observe_on(pool)
         .map(waste_time)
-        .to_shared()
+        .into_shared()
         .subscribe(move |v| *c_last.lock().unwrap() = v);
 
       // todo: no way to wait all task has finished in `ThreadPool`.
@@ -186,7 +186,7 @@ mod test {
       observable::from_iter(0..1000)
         .observe_on(local)
         .map(waste_time)
-        .to_shared()
+        .into_shared()
         .subscribe(move |v| *c_last.lock().unwrap() = v);
 
       // todo: no way to wait all task has finished in `Tokio` Scheduler.
@@ -207,7 +207,7 @@ mod test {
       observable::from_iter(0..1000)
         .observe_on(pool)
         .map(waste_time)
-        .to_shared()
+        .into_shared()
         .subscribe(move |v| *c_last.lock().unwrap() = v);
 
       // todo: no way to wait all task has finished in `Tokio` Scheduler.

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -17,7 +17,7 @@ pub trait SharedObservable: Observable {
 
   /// Convert to a thread-safe mode.
   #[inline]
-  fn to_shared(self) -> Shared<Self>
+  fn into_shared(self) -> Shared<Self>
   where
     Self: Sized,
   {

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -158,7 +158,7 @@ mod test {
   }
 
   #[test]
-  fn empty_local_subject_can_convert_to_shared() {
+  fn empty_local_subject_can_convert_into_shared() {
     let pool = ThreadPool::new().unwrap();
     use std::sync::{Arc, Mutex};
     let value = Arc::new(Mutex::new(0));
@@ -166,9 +166,9 @@ mod test {
     let mut subject = Subject::new();
     subject
       .clone()
-      .to_shared()
+      .into_shared()
       .observe_on(pool)
-      .to_shared()
+      .into_shared()
       .subscribe(move |v: i32| {
         *value.lock().unwrap() = v;
       });

--- a/src/subject/shared_subject.rs
+++ b/src/subject/shared_subject.rs
@@ -37,7 +37,7 @@ fn smoke() {
   let test_code = Arc::new(Mutex::new("".to_owned()));
   let mut subject = SharedSubject::new();
   let c_test_code = test_code.clone();
-  subject.clone().to_shared().subscribe(move |v: &str| {
+  subject.clone().into_shared().subscribe(move |v: &str| {
     *c_test_code.lock().unwrap() = v.to_owned();
   });
   subject.next("test shared subject");


### PR DESCRIPTION
BREAKING CHANGE: 🧨  rename `SharedObservable::to_shared` as `SharedObservable::into_shared`