### PR TITLE
Implement subscribe blocking for shared observables

### DIFF
--- a/src/observable.rs
+++ b/src/observable.rs
@@ -19,6 +19,12 @@ pub use connectable_observable::{
   SharedConnectableObservable,
 };
 
+mod observable_block_all;
+pub use observable_block_all::*;
+
+mod observable_block;
+pub use observable_block::*;
+
 mod base;
 pub use base::*;
 
@@ -34,6 +40,7 @@ pub use observable_next::*;
 mod observable_comp;
 
 mod defer;
+
 pub use defer::*;
 
 use crate::prelude::*;

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -20,9 +20,11 @@ pub use connectable_observable::{
 };
 
 mod observable_block_all;
+#[cfg(test)]
 pub use observable_block_all::*;
 
 mod observable_block;
+#[cfg(test)]
 pub use observable_block::*;
 
 mod base;

--- a/src/observable/observable_block.rs
+++ b/src/observable/observable_block.rs
@@ -1,0 +1,122 @@
+use crate::prelude::*;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct ObserverBlock<N, Item, Err> {
+  next: N,
+  is_stopped: Arc<Mutex<bool>>,
+  marker: TypeHint<(*const Item, *const Err)>,
+}
+
+impl<Item, Err, N> ObserverBlock<N, Item, Err> {
+  #[inline(always)]
+  pub fn new(next: N) -> Self {
+    ObserverBlock {
+      next,
+      is_stopped: Arc::new(Mutex::new(false)),
+      marker: TypeHint::new(),
+    }
+  }
+}
+
+impl<Item, Err, N> Observer for ObserverBlock<N, Item, Err>
+where
+  N: FnMut(Item),
+{
+  type Item = Item;
+  type Err = Err;
+  #[inline(always)]
+  fn next(&mut self, value: Self::Item) { (self.next)(value); }
+
+  fn error(&mut self, _err: Self::Err) {
+    *self.is_stopped.lock().unwrap() = true;
+  }
+
+  fn complete(&mut self) { *self.is_stopped.lock().unwrap() = true; }
+
+  #[inline]
+  fn is_stopped(&self) -> bool { *self.is_stopped.lock().unwrap() }
+}
+
+pub trait SubscribeBlocking<'a, N> {
+  /// A type implementing [`SubscriptionLike`]
+  type Unsub: SubscriptionLike;
+
+  /// Invokes an execution of an Observable that will block the subscribing
+  /// thread useful for testing and last resort blocking in token scenarios.
+  ///
+  /// Will return a SubscriptionWrapper only after upstream completion.
+  ///
+  /// Should preferably not be used in production because of both its blocking
+  /// nature, as well as its implementation by an arbitrarily chosen 1ms
+  /// thread sleep which goes against reactive programming philosophy.
+  ///
+  /// Use with caution, will block forever if the upstream never completes or
+  /// errors out.
+  ///
+  /// * `error`: A handler for a terminal event resulting from an error.
+  /// * `complete`: A handler for a terminal event resulting from successful
+  /// completion.
+  fn subscribe_blocking(self, next: N) -> SubscriptionWrapper<Self::Unsub>;
+}
+
+impl<'a, S, N> SubscribeBlocking<'a, N> for Shared<S>
+where
+  S: SharedObservable,
+  N: FnMut(S::Item) + Send + Sync + 'static,
+  S::Err: 'static,
+  S::Item: 'static,
+{
+  type Unsub = S::Unsub;
+  fn subscribe_blocking(self, next: N) -> SubscriptionWrapper<Self::Unsub>
+  where
+    Self: Sized,
+  {
+    let stopped = Arc::new(Mutex::new(false));
+    let stopped_c = Arc::clone(&stopped);
+    let subscriber = Subscriber::shared(ObserverBlock {
+      next,
+      is_stopped: stopped,
+      marker: TypeHint::new(),
+    });
+    let sub = SubscriptionWrapper(self.actual_subscribe(subscriber));
+    while !*stopped_c.lock().unwrap() {
+      std::thread::sleep(Duration::from_millis(1))
+    }
+    sub
+  }
+}
+
+#[cfg(test)]
+mod test {
+  extern crate test;
+  use crate::prelude::*;
+  use futures::executor::ThreadPool;
+  use std::sync::{Arc, Mutex};
+  use std::time::{Duration, Instant};
+
+  #[test]
+  fn blocks_shared() {
+    let pool = ThreadPool::new().unwrap();
+    let stamp = Instant::now();
+    let interval = observable::interval(Duration::from_millis(1), pool)
+      .take(5)
+      .into_shared();
+
+    let first = Arc::new(Mutex::new(0));
+    let first_clone = Arc::clone(&first);
+    interval
+      .clone()
+      .subscribe_blocking(move |_| *first_clone.lock().unwrap() += 1);
+    assert_eq!(*first.lock().unwrap(), 5);
+
+    let second = Arc::new(Mutex::new(0));
+    let second_clone = Arc::clone(&second);
+    interval.subscribe_blocking(move |_| *second_clone.lock().unwrap() += 1);
+    assert_eq!(*first.lock().unwrap(), 5);
+    assert_eq!(*second.lock().unwrap(), 5);
+
+    assert!(stamp.elapsed() > Duration::from_millis(10));
+  }
+}

--- a/src/observable/observable_block_all.rs
+++ b/src/observable/observable_block_all.rs
@@ -1,3 +1,4 @@
+#![cfg(test)]
 use crate::prelude::*;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;

--- a/src/observable/observable_block_all.rs
+++ b/src/observable/observable_block_all.rs
@@ -1,0 +1,152 @@
+use crate::prelude::*;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct ObserverBlockAll<N, E, C, Item, Err> {
+  next: N,
+  error: E,
+  complete: C,
+  is_stopped: Arc<Mutex<bool>>,
+  marker: TypeHint<(*const Item, *const Err)>,
+}
+
+impl<Item, Err, N, E, C> ObserverBlockAll<N, E, C, Item, Err> {
+  #[inline(always)]
+  pub fn new(next: N, error: E, complete: C) -> Self {
+    ObserverBlockAll {
+      next,
+      error,
+      complete,
+      is_stopped: Arc::new(Mutex::new(false)),
+      marker: TypeHint::new(),
+    }
+  }
+}
+
+impl<Item, Err, N, E, C> Observer for ObserverBlockAll<N, E, C, Item, Err>
+where
+  C: FnMut(),
+  N: FnMut(Item),
+  E: FnMut(Err),
+{
+  type Item = Item;
+  type Err = Err;
+  #[inline(always)]
+  fn next(&mut self, value: Self::Item) { (self.next)(value); }
+
+  fn error(&mut self, err: Self::Err) {
+    (self.error)(err);
+    *self.is_stopped.lock().unwrap() = true;
+  }
+
+  fn complete(&mut self) {
+    (self.complete)();
+    *self.is_stopped.lock().unwrap() = true;
+  }
+
+  #[inline]
+  fn is_stopped(&self) -> bool { *self.is_stopped.lock().unwrap() }
+}
+
+pub trait SubscribeBlockingAll<'a, N, E, C> {
+  /// A type implementing [`SubscriptionLike`]
+  type Unsub: SubscriptionLike;
+
+  /// Invokes an execution of an Observable that will block the subscribing
+  /// thread; useful for testing and last resort blocking in token scenarios.
+  ///
+  /// Will return a SubscriptionWrapper only after upstream completion.
+  ///
+  /// Should preferably not be used in production because of both its blocking
+  /// nature, as well as its implementation by an arbitrarily chosen 1ms
+  /// thread sleep which goes against reactive programming philosophy.
+  ///
+  /// Use with caution, will block forever if the upstream never completes or
+  /// errors out.
+  ///
+  /// * `error`: A handler for a terminal event resulting from an error.
+  /// * `complete`: A handler for a terminal event resulting from successful
+  /// completion.
+  fn subscribe_blocking_all(
+    self,
+    next: N,
+    error: E,
+    complete: C,
+  ) -> SubscriptionWrapper<Self::Unsub>;
+}
+
+impl<'a, S, N, E, C> SubscribeBlockingAll<'a, N, E, C> for Shared<S>
+where
+  S: SharedObservable,
+  N: FnMut(S::Item) + Send + Sync + 'static,
+  E: FnMut(S::Err) + Send + Sync + 'static,
+  C: FnMut() + Send + Sync + 'static,
+  S::Err: 'static,
+  S::Item: 'static,
+{
+  type Unsub = S::Unsub;
+  fn subscribe_blocking_all(
+    self,
+    next: N,
+    error: E,
+    complete: C,
+  ) -> SubscriptionWrapper<Self::Unsub>
+  where
+    Self: Sized,
+  {
+    let stopped = Arc::new(Mutex::new(false));
+    let stopped_c = Arc::clone(&stopped);
+    let subscriber = Subscriber::shared(ObserverBlockAll {
+      next,
+      error,
+      complete,
+      is_stopped: stopped,
+      marker: TypeHint::new(),
+    });
+    let sub = SubscriptionWrapper(self.0.actual_subscribe(subscriber));
+    while !*stopped_c.lock().unwrap() {
+      std::thread::sleep(Duration::from_millis(1))
+    }
+    sub
+  }
+}
+
+#[cfg(test)]
+mod test {
+  extern crate test;
+  use crate::prelude::*;
+  use futures::executor::ThreadPool;
+  use std::sync::{Arc, Mutex};
+  use std::time::{Duration, Instant};
+
+  #[test]
+  fn blocks_shared() {
+    let pool = ThreadPool::new().unwrap();
+    let stamp = Instant::now();
+    let interval = observable::interval(Duration::from_millis(1), pool)
+      .take(5)
+      .into_shared();
+
+    let first = Arc::new(Mutex::new(0));
+    let first_clone = Arc::clone(&first);
+    interval.clone().subscribe_blocking_all(
+      move |_| *first_clone.lock().unwrap() += 1,
+      |_| {},
+      || {},
+    );
+    assert_eq!(*first.lock().unwrap(), 5);
+
+    let second = Arc::new(Mutex::new(0));
+    let second_clone = Arc::clone(&second);
+    interval.subscribe_blocking_all(
+      move |_| *second_clone.lock().unwrap() += 1,
+      |_| {},
+      || {},
+    );
+
+    assert_eq!(*first.lock().unwrap(), 5);
+    assert_eq!(*second.lock().unwrap(), 5);
+    assert!(stamp.elapsed() > Duration::from_millis(10));
+  }
+}


### PR DESCRIPTION
This PR partially addresses https://github.com/rxRust/rxRust/issues/26 by implementing subscribe blocking on shared observables. Using this `observable::interval::tests::shared` as well as `ops::delay::tests::shared_smoke` tests becomes stable without timing issues.

It's only implemented on shared observables, since local observables blocks by nature making a local observble implementation confusing, if I'm not mistaken.

`ops::throttle_time::tests::smoke`,` ops::sample::test::sample_base`, and  are still unstable as they operate on a local scheduler. As the subscribe_blocking function blocks the executing thread this means that that same thread cannot be used to schedule new intervals causing an infinite lock. Therefore, testing a local emitter using a local scheduler becomes impossible with my implementation.

The cause of this problem is that we can't have local observables with a shared threadpool, this should be possible since the interval/timed tasks should be outsourcable to some other arbitrary scheduler while the local thread blocks on the subscription. A suggestion is to not take a scheduler at all in the local case and just have the calling thread execute the wait and delay without a LocalSpawner, but I don't know how feasible that implementation is.

This implementation is a bit ugly/hackish, would love to get some feedback on it!