### PR TITLE
feat: 🎸 Implement take_while_inclusive operator

### DIFF
--- a/src/observable.rs
+++ b/src/observable.rs
@@ -667,6 +667,40 @@ pub trait Observable: Sized {
     TakeWhileOp {
       source: self,
       callback,
+      inclusive: false,
+    }
+  }
+
+  /// Emits values while result of an callback is true and the last one that
+  /// causes the callback to return false.
+  ///
+  /// # Example
+  /// Take the first 5 seconds of an infinite 1-second interval Observable
+  ///
+  /// ```
+  /// # use rxrust::prelude::*;
+  ///
+  /// observable::from_iter(0..10)
+  ///   .take_while_inclusive(|v| v < &4)
+  /// .subscribe(|v| println!("{}", v));
+
+  /// // print logs:
+  /// // 0
+  /// // 1
+  /// // 2
+  /// // 3
+  /// // 4
+  /// ```
+  ///
+  #[inline]
+  fn take_while_inclusive<F>(self, callback: F) -> TakeWhileOp<Self, F>
+  where
+    F: FnMut(&Self::Item) -> bool,
+  {
+    TakeWhileOp {
+      source: self,
+      callback,
+      inclusive: true,
     }
   }
 


### PR DESCRIPTION
Implemented take_while_inclusive operator.

This is take_while operator with inclusive flag on in RxJS. I made this as separate operator to avoid breaking existing interface of take_while. But I think it's less ugly when we make it as a parameter of existing `take_while` operator, like `take_while(predicate, false)` or `take_while(predicate, true)`.