### PR TITLE
feat: 🎸 Implement `distinct_key` and `distinct_key_until_changed` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - **operator**: add `start_with` operator.
 - **operator**: add `start` operator.
 - **operator**: add `distinct_until_changed` operator.
+- **operator**: add `distinct_key` operator.
+- **operator**: add `distinct_key_until_changed` operator.
 
 ## [1.0.0-alpha.2](https://github.com/rxRust/rxRust/releases/tag/v1.0.0-alpha.2)
 ### Features

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -48,6 +48,7 @@ use crate::prelude::*;
 pub use observable_comp::*;
 
 use crate::ops::default_if_empty::DefaultIfEmptyOp;
+use crate::ops::distinct::DistinctUntilKeyChangedOp;
 use ops::{
   box_it::{BoxOp, IntoBox},
   buffer::{BufferWithCountOp, BufferWithCountOrTimerOp, BufferWithTimeOp},
@@ -1266,6 +1267,15 @@ pub trait Observable: Sized {
   #[inline]
   fn distinct_until_changed(self) -> DistinctUntilChangedOp<Self> {
     DistinctUntilChangedOp { source: self }
+  }
+
+  /// Only emit when the current value is different than the last
+  #[inline]
+  fn distinct_until_key_changed<F>(
+    self,
+    key: F,
+  ) -> DistinctUntilKeyChangedOp<Self, F> {
+    DistinctUntilKeyChangedOp { source: self, key }
   }
 
   /// 'Zips up' two observable into a single observable of pairs.

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -48,7 +48,7 @@ use crate::prelude::*;
 pub use observable_comp::*;
 
 use crate::ops::default_if_empty::DefaultIfEmptyOp;
-use crate::ops::distinct::DistinctUntilKeyChangedOp;
+use crate::ops::distinct::{DistinctKeyOp, DistinctUntilKeyChangedOp};
 use ops::{
   box_it::{BoxOp, IntoBox},
   buffer::{BufferWithCountOp, BufferWithCountOrTimerOp, BufferWithTimeOp},
@@ -1263,13 +1263,19 @@ pub trait Observable: Sized {
   #[inline]
   fn distinct(self) -> DistinctOp<Self> { DistinctOp { source: self } }
 
+  /// Variant of distinct that takes a key selector.
+  #[inline]
+  fn distinct_key<F>(self, key: F) -> DistinctKeyOp<Self, F> {
+    DistinctKeyOp { source: self, key }
+  }
+
   /// Only emit when the current value is different than the last
   #[inline]
   fn distinct_until_changed(self) -> DistinctUntilChangedOp<Self> {
     DistinctUntilChangedOp { source: self }
   }
 
-  /// Only emit when the current value is different than the last
+  /// Variant of distinct_until_changed that takes a key selector.
   #[inline]
   fn distinct_until_key_changed<F>(
     self,

--- a/src/ops/distinct.rs
+++ b/src/ops/distinct.rs
@@ -51,6 +51,63 @@ where
 }
 
 #[derive(Clone)]
+pub struct DistinctKeyOp<S, F> {
+  pub(crate) source: S,
+  pub(crate) key: F,
+}
+
+impl<S: Observable, F> Observable for DistinctKeyOp<S, F> {
+  type Item = S::Item;
+  type Err = S::Err;
+}
+
+impl_local_shared_both! {
+  impl<S, F, K> DistinctKeyOp<S, F>;
+  type Unsub = S::Unsub;
+  macro method($self: ident, $observer: ident, $ctx: ident) {
+    $self.source.actual_subscribe(DistinctKeyObserver {
+      observer: $observer,
+      key: $self.key,
+      seen: HashSet::new(),
+    })
+  }
+  where
+    S: @ctx::Observable,
+    F: Fn(&S::Item) -> K
+      @ctx::local_only(+ 'o)
+      @ctx::shared_only(+ Send + Sync + 'static),
+    K: Eq + Hash + Clone
+      @ctx::local_only(+ 'o)
+      @ctx::shared_only(+ Send + Sync + 'static),
+}
+struct DistinctKeyObserver<O, F, K> {
+  observer: O,
+  key: F,
+  seen: HashSet<K>,
+}
+
+impl<O, F, K, Item, Err> Observer for DistinctKeyObserver<O, F, K>
+where
+  O: Observer<Item = Item, Err = Err>,
+  K: Hash + Eq + Clone,
+  F: Fn(&Item) -> K,
+{
+  type Item = Item;
+  type Err = Err;
+  fn next(&mut self, value: Self::Item) {
+    let key = (self.key)(&value);
+    if !self.seen.contains(&key) {
+      self.seen.insert(key);
+      self.observer.next(value);
+    }
+  }
+
+  fn error(&mut self, err: Self::Err) { self.observer.error(err) }
+
+  fn complete(&mut self) { self.observer.complete() }
+}
+
+#[derive(Clone)]
 pub struct DistinctUntilChangedOp<S> {
   pub(crate) source: S,
 }
@@ -232,5 +289,19 @@ mod tests {
     .subscribe(move |v| x.borrow_mut().push(v))
     .unsubscribe();
     assert_eq!(&*x_c.borrow(), &[(1, 2), (2, 2), (1, 1), (2, 2), (3, 2)]);
+  }
+
+  #[test]
+  fn distinct_key() {
+    let x = Rc::new(RefCell::new(vec![]));
+    let x_c = x.clone();
+    observable::from_iter(
+      vec![(1, 2), (2, 2), (2, 1), (1, 1), (2, 2), (3, 2)].into_iter(),
+    )
+    .map(|v| v)
+    .distinct_key(|tup: &(i32, i32)| tup.0)
+    .subscribe(move |v| x.borrow_mut().push(v))
+    .unsubscribe();
+    assert_eq!(&*x_c.borrow(), &[(1, 2), (2, 2), (3, 2)]);
   }
 }


### PR DESCRIPTION
Implement `distinct_key` and `distinct_key_until_changed` operator.

Each operators are variant of `distinct` and `distinct_until_changed` respectively. They work the same way except that comparison is done on the result of given key selector.