### PR TITLE
feat: 🎸 Implement `pairwise` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **operator**: add `distinct_until_changed` operator.
 - **operator**: add `distinct_key` operator.
 - **operator**: add `distinct_key_until_changed` operator.
+- **operator**: add `pairwise` operator.
 
 ## [1.0.0-alpha.2](https://github.com/rxRust/rxRust/releases/tag/v1.0.0-alpha.2)
 ### Features

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -49,6 +49,7 @@ pub use observable_comp::*;
 
 use crate::ops::default_if_empty::DefaultIfEmptyOp;
 use crate::ops::distinct::{DistinctKeyOp, DistinctUntilKeyChangedOp};
+use crate::ops::pairwise::PairwiseOp;
 use ops::{
   box_it::{BoxOp, IntoBox},
   buffer::{BufferWithCountOp, BufferWithCountOrTimerOp, BufferWithTimeOp},
@@ -1516,6 +1517,10 @@ pub trait Observable: Sized {
       values,
     }
   }
+
+  /// Groups pairs of consecutive emissions together and emits them as an pair
+  /// of two values.
+  fn pairwise(self) -> PairwiseOp<Self> { PairwiseOp { source: self } }
 }
 
 pub trait LocalObservable<'a>: Observable {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -17,6 +17,7 @@ pub mod map_to;
 pub mod merge;
 pub mod merge_all;
 pub mod observe_on;
+pub mod pairwise;
 pub mod ref_count;
 pub mod sample;
 pub mod scan;

--- a/src/ops/pairwise.rs
+++ b/src/ops/pairwise.rs
@@ -46,8 +46,8 @@ where
     let (_x, y) = std::mem::take(&mut self.pair);
     self.pair = (y, Some(value));
 
-    if let (Some(a), Some(b)) = self.pair.clone() {
-      self.observer.next((a, b));
+    if let (Some(a), Some(b)) = &self.pair {
+      self.observer.next((a.clone(), b.clone()));
     }
   }
 

--- a/src/ops/pairwise.rs
+++ b/src/ops/pairwise.rs
@@ -1,0 +1,83 @@
+use crate::{impl_local_shared_both, prelude::*};
+
+#[derive(Clone)]
+pub struct PairwiseOp<S> {
+  pub(crate) source: S,
+}
+
+impl<S: Observable> Observable for PairwiseOp<S> {
+  type Item = (S::Item, S::Item);
+  type Err = S::Err;
+}
+
+impl_local_shared_both! {
+  impl<S> PairwiseOp<S>;
+  type Unsub = S::Unsub;
+  macro method($self: ident, $observer: ident, $ctx: ident) {
+    $self
+    .source
+    .actual_subscribe(PairwiseObserver{
+      observer: $observer,
+      pair: (None, None),
+    })
+  }
+  where
+    S: @ctx::Observable,
+    S::Item: Clone
+      @ctx::shared_only(+ Send + Sync + 'static)
+      @ctx::local_only(+ 'o)
+}
+
+#[derive(Clone)]
+pub struct PairwiseObserver<O, Item> {
+  observer: O,
+  pair: (Option<Item>, Option<Item>),
+}
+
+impl<O, Item, Err> Observer for PairwiseObserver<O, Item>
+where
+  O: Observer<Item = (Item, Item), Err = Err>,
+  Item: Clone,
+{
+  type Item = Item;
+  type Err = Err;
+
+  fn next(&mut self, value: Self::Item) {
+    let (_x, y) = std::mem::take(&mut self.pair);
+    self.pair = (y, Some(value));
+
+    if let (Some(a), Some(b)) = self.pair.clone() {
+      self.observer.next((a, b));
+    }
+  }
+
+  fn complete(&mut self) { self.observer.complete(); }
+
+  fn error(&mut self, err: Self::Err) { self.observer.error(err) }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn smoke() {
+    let expected = vec![
+      (0, 1),
+      (1, 2),
+      (2, 3),
+      (3, 4),
+      (4, 5),
+      (5, 6),
+      (6, 7),
+      (7, 8),
+      (8, 9),
+    ];
+    let mut actual = vec![];
+    observable::from_iter(0..10)
+      .pairwise()
+      .subscribe(|pair| actual.push(pair));
+
+    assert_eq!(expected, actual);
+  }
+}


### PR DESCRIPTION
Implemented `pairwise` operator. It groups pairs of consecutive emissions together and emits them as an pair of two values.