### PR TITLE
Replace trait 'Fn' with 'FnMut'

### DIFF
--- a/src/observable.rs
+++ b/src/observable.rs
@@ -308,7 +308,7 @@ pub trait Observable: Sized {
   #[inline]
   fn map<B, F>(self, f: F) -> MapOp<Self, F>
   where
-    F: Fn(Self::Item) -> B,
+    F: FnMut(Self::Item) -> B,
   {
     MapOp {
       source: self,

--- a/src/ops/start_with.rs
+++ b/src/ops/start_with.rs
@@ -99,7 +99,7 @@ mod test {
       let s = of_sequence!(" World!", " Goodbye", " World!");
 
       s.start_with(vec!["Hello"]).subscribe(|value| {
-        ret.push_str(&value.to_string());
+        ret.push_str(value);
       });
     }
 


### PR DESCRIPTION
This revision includes:
- Replace trait 'Fn' with 'FnMut'
  - My project should call method using `&mut self` in operator `map`. To resolve this problem, the trait `Fn` should replace with `FnMut`.