### PR TITLE
Added `wasm` support

### DIFF
--- a/src/impl_helper.rs
+++ b/src/impl_helper.rs
@@ -276,9 +276,11 @@ macro_rules! impl_local_shared_both {
   // enter replace
   ($($t:tt)*) => {
     impl_local_shared_both!(@replace, impl_local, [] $($t)*);
+    #[cfg(not(target_arch = "wasm32"))]
     impl_local_shared_both!(@replace, impl_shared, [] $($t)*);
   };
 }
+
 pub mod impl_local {
   use crate::prelude::*;
   // macro builtin replace.
@@ -303,6 +305,7 @@ pub mod impl_local {
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod impl_shared {
   use crate::prelude::*;
   // macro builtin replace.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![recursion_limit = "256"]
 #![feature(generic_associated_types)]
 #![doc = include_str!("../README.md")]
+#![cfg_attr(all(test, target_arch = "wasm32"), allow(unused_imports))]
 
 #[cfg(test)]
 extern crate float_cmp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod observer;
 pub mod ops;
 pub mod rc;
 pub mod scheduler;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod shared;
 pub mod subject;
 pub mod subscription;
@@ -35,6 +36,7 @@ pub mod prelude {
   pub use crate::ops;
   pub use crate::rc::*;
   pub use crate::scheduler::*;
+  #[cfg(not(target_arch = "wasm32"))]
   pub use crate::shared;
   pub use crate::subject;
   pub use crate::subject::*;
@@ -42,5 +44,6 @@ pub mod prelude {
   pub use crate::subscription::*;
   pub use crate::type_hint::TypeHint;
   pub use observer::Observer;
+  #[cfg(not(target_arch = "wasm32"))]
   pub use shared::*;
 }

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1646,6 +1646,7 @@ mod tests {
     b.iter(smoke_ignore_elements);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared_ignore_elements() {
     observable::from_iter(0..20)

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -104,6 +104,7 @@ where
   fn connect(self) -> Self::Unsub { self.source.actual_subscribe(self.subject) }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 type SharedInnerRefCount<Src> = MutArc<
   InnerRefCount<
     Src,
@@ -112,6 +113,7 @@ type SharedInnerRefCount<Src> = MutArc<
   >,
 >;
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Src> Connect
   for ConnectableObservable<Src, SharedSubject<Src::Item, Src::Err>>
 where

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -149,6 +149,7 @@ mod test {
     assert_eq!(second, 100);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     let o = observable::of(100);

--- a/src/observable/defer.rs
+++ b/src/observable/defer.rs
@@ -52,6 +52,7 @@ mod test {
   use crate::prelude::*;
   use bencher::Bencher;
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn no_results_before_deferred_subscribe() {
     let calls = Arc::new(Mutex::new(0));
@@ -104,6 +105,7 @@ mod test {
     assert_eq!(*calls.lock().unwrap().deref(), 2);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_share() {
     let observable = observable::defer(observable::empty);
@@ -115,11 +117,14 @@ mod test {
     observable.subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn bench() { do_bench(); }
 
+  #[cfg(not(target_arch = "wasm32"))]
   benchmark_group!(do_bench, bench_deref);
 
+  #[cfg(not(target_arch = "wasm32"))]
   fn bench_deref(b: &mut Bencher) {
     b.iter(no_results_before_deferred_subscribe);
   }

--- a/src/observable/from_fn.rs
+++ b/src/observable/from_fn.rs
@@ -36,6 +36,7 @@ mod test {
   use bencher::Bencher;
   use std::sync::{Arc, Mutex};
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn proxy_call() {
     let next = Arc::new(Mutex::new(0));
@@ -83,6 +84,7 @@ mod test {
     assert_eq!(*c_sum2.lock().unwrap(), 10);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_share() {
     let observable = observable::create(|_| {});
@@ -94,10 +96,13 @@ mod test {
     observable.clone().subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn bench() { do_bench(); }
 
+  #[cfg(not(target_arch = "wasm32"))]
   benchmark_group!(do_bench, bench_from_fn);
 
+  #[cfg(not(target_arch = "wasm32"))]
   fn bench_from_fn(b: &mut Bencher) { b.iter(proxy_call); }
 }

--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -130,6 +130,7 @@ mod tests {
     sync::{Arc, Mutex},
   };
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared() {
     let res = Arc::new(Mutex::new(0));

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -60,6 +60,7 @@ mod tests {
   use futures::executor::{LocalPool, ThreadPool};
   use std::sync::{Arc, Mutex};
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared() {
     let millis = Arc::new(Mutex::new(0));

--- a/src/observable/observable_all.rs
+++ b/src/observable/observable_all.rs
@@ -86,6 +86,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a, S, N, E, C> SubscribeAll<'a, N, E, C> for Shared<S>
 where
   S: SharedObservable,

--- a/src/observable/observable_block.rs
+++ b/src/observable/observable_block.rs
@@ -60,6 +60,7 @@ pub trait SubscribeBlocking<'a, N> {
   fn subscribe_blocking(self, next: N) -> SubscriptionWrapper<Self::Unsub>;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a, S, N> SubscribeBlocking<'a, N> for Shared<S>
 where
   S: SharedObservable<Err = ()>,
@@ -93,7 +94,7 @@ mod test {
   use std::sync::{Arc, Mutex};
   use std::time::{Duration, Instant};
 
-  #[test]
+  #[cfg(not(target_arch = "wasm32"))]
   fn blocks_shared() {
     let pool = ThreadPool::new().unwrap();
     let stamp = Instant::now();

--- a/src/observable/observable_block_all.rs
+++ b/src/observable/observable_block_all.rs
@@ -75,6 +75,7 @@ pub trait SubscribeBlockingAll<'a, N, E, C> {
   ) -> SubscriptionWrapper<Self::Unsub>;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a, S, N, E, C> SubscribeBlockingAll<'a, N, E, C> for Shared<S>
 where
   S: SharedObservable,
@@ -118,6 +119,7 @@ mod test {
   use std::sync::{Arc, Mutex};
   use std::time::{Duration, Instant};
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn blocks_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/observable/observable_comp.rs
+++ b/src/observable/observable_comp.rs
@@ -71,6 +71,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a, S, N, C> SubscribeComplete<'a, N, C> for Shared<S>
 where
   S: SharedObservable<Err = ()>,

--- a/src/observable/observable_err.rs
+++ b/src/observable/observable_err.rs
@@ -68,6 +68,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a, S, N, E> SubscribeErr<'a, N, E> for Shared<S>
 where
   S: SharedObservable,

--- a/src/observable/observable_next.rs
+++ b/src/observable/observable_next.rs
@@ -50,6 +50,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a, S, N> SubscribeNext<'a, N> for Shared<S>
 where
   S: SharedObservable<Err = ()>,

--- a/src/observable/start.rs
+++ b/src/observable/start.rs
@@ -49,6 +49,7 @@ mod tests {
     assert!(is_completed);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_emit_closure_value_shared() {
     let actual = Arc::new(AtomicI32::new(0));

--- a/src/observable/timer.rs
+++ b/src/observable/timer.rs
@@ -102,6 +102,7 @@ mod tests {
     assert_eq!(val, i_emitted.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_shall_emit_value_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -137,6 +138,7 @@ mod tests {
     assert_eq!(next_count.load(Ordering::Relaxed), 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_shall_call_next_once_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -174,6 +176,7 @@ mod tests {
     assert!(is_completed.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_shall_be_completed_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -208,6 +211,7 @@ mod tests {
     assert!(stamp.elapsed() >= duration);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_shall_elapse_duration_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -244,6 +248,7 @@ mod tests {
     assert_eq!(val, i_emitted.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_at_shall_emit_value_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -140,6 +140,7 @@ mod test {
     assert_eq!(6, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn reduce_fork_and_shared() {
     // type to type can fork
@@ -219,6 +220,7 @@ mod test {
     assert_eq!(None, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
 
   fn max_fork_and_shared() {
@@ -294,6 +296,7 @@ mod test {
     assert_eq!(None, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
 
   fn min_fork_and_shared() {
@@ -334,6 +337,7 @@ mod test {
     assert_eq!(-1, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn sum_fork_and_shared() {
     // type to type can fork
@@ -359,6 +363,7 @@ mod test {
     assert_eq!(0, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn count_fork_and_shared() {
     // type to type can fork
@@ -434,6 +439,7 @@ mod test {
     assert_eq!(None, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn average_fork_and_shared() {
     // type to type can fork

--- a/src/ops/box_it.rs
+++ b/src/ops/box_it.rs
@@ -232,8 +232,12 @@ where
 mod test {
   use crate::prelude::*;
   use bencher::Bencher;
-  use ops::box_it::{BoxClone, SharedBoxClone};
-  use ops::box_it::{LocalBoxOp, SharedBoxOp};
+  use ops::box_it::BoxClone;
+  use ops::box_it::LocalBoxOp;
+  #[cfg(not(target_arch = "wasm32"))]
+  use ops::box_it::SharedBoxClone;
+  #[cfg(not(target_arch = "wasm32"))]
+  use ops::box_it::SharedBoxOp;
 
   #[test]
   fn box_observable() {
@@ -246,6 +250,7 @@ mod test {
     assert_eq!(test, 100);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared_box_observable() {
     let mut boxed: SharedBoxOp<i32, ()> = observable::of(100).box_it();
@@ -263,6 +268,7 @@ mod test {
       .subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared_box_clone() {
     observable::of(100)

--- a/src/ops/box_it.rs
+++ b/src/ops/box_it.rs
@@ -9,6 +9,7 @@ pub trait BoxObservable<'a> {
   ) -> Box<dyn SubscriptionLike>;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub trait SharedBoxObservable {
   type Item;
   type Err;
@@ -45,6 +46,7 @@ where
   box_observable_impl!(LocalSubscription, T, 'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> SharedBoxObservable for T
 where
   T: SharedObservable,
@@ -66,8 +68,11 @@ pub type LocalBoxOp<'a, Item, Err> =
   BoxOp<Box<dyn BoxObservable<'a, Item = Item, Err = Err> + 'a>>;
 pub type LocalCloneBoxOp<'a, Item, Err> =
   BoxOp<Box<dyn BoxClone<'a, Item = Item, Err = Err> + 'a>>;
+// #[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub type SharedBoxOp<Item, Err> =
   BoxOp<Box<dyn SharedBoxObservable<Item = Item, Err = Err> + Send + Sync>>;
+#[cfg(not(target_arch = "wasm32"))]
 pub type SharedCloneBoxOp<Item, Err> =
   BoxOp<Box<dyn SharedBoxClone<Item = Item, Err = Err>>>;
 
@@ -93,11 +98,13 @@ impl<'a, Item, Err> LocalObservable<'a> for LocalBoxOp<'a, Item, Err> {
   observable_impl!(LocalSubscription, 'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, Err> Observable for SharedBoxOp<Item, Err> {
   type Item = Item;
   type Err = Err;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, Err> SharedObservable for SharedBoxOp<Item, Err> {
   type Unsub = Box<dyn SubscriptionLike + Send + Sync>;
   observable_impl!(SharedSubscription, Send + Sync + 'static);
@@ -112,10 +119,13 @@ impl<'a, Item, Err> LocalObservable<'a> for LocalCloneBoxOp<'a, Item, Err> {
   observable_impl!(LocalSubscription, 'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, Err> Observable for SharedCloneBoxOp<Item, Err> {
   type Item = Item;
   type Err = Err;
 }
+
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, Err> SharedObservable for SharedCloneBoxOp<Item, Err> {
   type Unsub = Box<dyn SubscriptionLike + Send + Sync>;
   observable_impl!(SharedSubscription, Send + Sync + 'static);
@@ -139,6 +149,7 @@ where
   fn box_it(origin: T) -> BoxOp<Self> { BoxOp(Box::new(origin)) }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> IntoBox<T>
   for Box<dyn SharedBoxObservable<Item = T::Item, Err = T::Err> + Send + Sync>
 where
@@ -184,12 +195,14 @@ where
   fn box_it(origin: T) -> BoxOp<Self> { BoxOp(Box::new(origin)) }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub trait SharedBoxClone: SharedBoxObservable {
   fn box_clone(
     &self,
   ) -> Box<dyn SharedBoxClone<Item = Self::Item, Err = Self::Err>>;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> SharedBoxClone for T
 where
   T: SharedBoxObservable + Clone + 'static,
@@ -201,11 +214,13 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, Err> Clone for Box<dyn SharedBoxClone<Item = Item, Err = Err>> {
   #[inline]
   fn clone(&self) -> Self { self.box_clone() }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a, T> IntoBox<T> for Box<dyn SharedBoxClone<Item = T::Item, Err = T::Err>>
 where
   T: SharedBoxObservable + Clone + 'static,

--- a/src/ops/buffer.rs
+++ b/src/ops/buffer.rs
@@ -276,6 +276,7 @@ mod tests {
     assert_eq!(expected, actual);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_buffer_with_count_shared() {
     let expected =
@@ -373,6 +374,7 @@ mod tests {
     local.run();
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_buffer_with_time_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -411,6 +413,7 @@ mod tests {
     assert!(is_completed.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_not_emit_buffer_with_time_on_error() {
     let pool = ThreadPool::new().unwrap();
@@ -501,6 +504,7 @@ mod tests {
     assert!(error_called.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_buffer_with_count_or_time_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -537,6 +541,7 @@ mod tests {
     assert!(is_completed.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_buffer_with_count_or_time_shared_on_error() {
     let pool = ThreadPool::new().unwrap();

--- a/src/ops/contains.rs
+++ b/src/ops/contains.rs
@@ -95,6 +95,7 @@ mod test {
     observable::empty().contains(1).subscribe(|b| assert!(!b));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn contains_shared() {
     observable::from_iter(0..10)

--- a/src/ops/contains.rs
+++ b/src/ops/contains.rs
@@ -40,6 +40,7 @@ where
   observable_impl!(LocalSubscription,'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, S> SharedObservable for ContainsOp<S, Item>
 where
   S: SharedObservable<Item = Item>,

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -95,7 +95,9 @@ macro_rules! impl_observer {
 }
 
 impl_observer!(MutRc, LocalScheduler);
+#[cfg(not(target_arch = "wasm32"))]
 impl_observer!(MutArc, SharedScheduler, Send);
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -146,6 +146,7 @@ mod tests {
     assert_eq!(&*x_c.rc_deref(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     use futures::executor::ThreadPool;

--- a/src/ops/default_if_empty.rs
+++ b/src/ops/default_if_empty.rs
@@ -94,6 +94,7 @@ mod test {
     assert!(completed);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn into_shared() {
     observable::from_iter(0..100)
@@ -102,6 +103,7 @@ mod test {
       .subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared_empty() {
     observable::empty()

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -47,6 +47,7 @@ mod tests {
     sync::{Arc, Mutex},
   };
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared_smoke() {
     let value = Arc::new(Mutex::new(0));

--- a/src/ops/distinct.rs
+++ b/src/ops/distinct.rs
@@ -233,6 +233,7 @@ mod tests {
       .unsubscribe();
     assert_eq!(&*x_c.borrow(), &[0, 1, 2, 3, 4]);
   }
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared() {
     observable::from_iter(0..10)
@@ -259,6 +260,7 @@ mod tests {
       .unsubscribe();
     assert_eq!(&*x_c.borrow(), &[1, 2, 1, 2, 3]);
   }
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn distinct_until_changed_shared() {
     observable::from_iter(0..10)

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -41,6 +41,7 @@ where
   observable_impl!(LocalSubscription, S, 'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<S, F> SharedObservable for FilterOp<S, F>
 where
   S: SharedObservable,

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -77,6 +77,7 @@ where
 mod test {
   use crate::prelude::*;
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     observable::from_iter(0..10)

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -42,6 +42,7 @@ where
   observable_impl!(LocalSubscription, 'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, S, F> SharedObservable for FilterMapOp<S, F>
 where
   S: SharedObservable,

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -90,6 +90,7 @@ mod test {
     assert_eq!(i, 3);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn filter_map_shared_and_fork() {
     observable::of(1)
@@ -99,6 +100,7 @@ mod test {
       .subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn filter_map_return_ref() {
     observable::of(&1)

--- a/src/ops/finalize.rs
+++ b/src/ops/finalize.rs
@@ -314,6 +314,7 @@ mod test {
     assert_eq!(finalize_count.get(), 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn finalize_shared() {
     // Given

--- a/src/ops/finalize.rs
+++ b/src/ops/finalize.rs
@@ -41,6 +41,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<S, F> SharedObservable for FinalizeOp<S, F>
 where
   S: SharedObservable,

--- a/src/ops/flatten.rs
+++ b/src/ops/flatten.rs
@@ -365,6 +365,7 @@ mod test {
     assert_eq!(*ec.lock().unwrap(), 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn flatten_local_and_shared() {
     let mut res = vec![];

--- a/src/ops/flatten.rs
+++ b/src/ops/flatten.rs
@@ -147,6 +147,7 @@ pub struct FlattenOuterObserver<Inner, InnerObserver, U, S> {
   state: S,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 type FlattenSharedOuterObserver<Inner, InnerObserver> = FlattenOuterObserver<
   Inner,
   MutArc<
@@ -190,6 +191,7 @@ macro_rules! impl_outer_obsrever {
   };
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Inner, O> Observer for FlattenSharedOuterObserver<Inner, O>
 where
   O: Observer + Sync + Send + 'static,

--- a/src/ops/group_by.rs
+++ b/src/ops/group_by.rs
@@ -68,6 +68,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Source, Discr, Key> SharedObservable
   for GroupObservable<Source, Discr, Key>
 where
@@ -170,6 +171,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<'a, Source, Discr, Key> SharedObservable for GroupByOp<Source, Discr>
 where
   Source: SharedObservable + Clone + Send + Sync + 'static,

--- a/src/ops/group_by.rs
+++ b/src/ops/group_by.rs
@@ -215,6 +215,7 @@ mod test {
     assert_eq!(obs_count, 2);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn group_by_shared() {
     let s = observable::of(0).group_by(|_| "zero");

--- a/src/ops/last.rs
+++ b/src/ops/last.rs
@@ -176,6 +176,7 @@ mod test {
     assert_eq!(default, 100);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn last_fork_and_shared() {
     observable::of(0)

--- a/src/ops/last.rs
+++ b/src/ops/last.rs
@@ -39,6 +39,7 @@ where
   observable_impl!(LocalSubscription, 'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, S> SharedObservable for LastOp<S, Item>
 where
   S: SharedObservable<Item = Item>,

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -75,6 +75,7 @@ mod test {
     assert_eq!(i, 100);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     // type to type can fork

--- a/src/ops/map_to.rs
+++ b/src/ops/map_to.rs
@@ -95,6 +95,7 @@ mod test {
     assert_eq!(i, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     // type to type can fork

--- a/src/ops/map_to.rs
+++ b/src/ops/map_to.rs
@@ -42,6 +42,7 @@ where
   observable_impl!(LocalSubscription,'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<B, S> SharedObservable for MapToOp<S, B>
 where
   S: SharedObservable,

--- a/src/ops/merge.rs
+++ b/src/ops/merge.rs
@@ -180,6 +180,7 @@ mod test {
     m.clone().merge(m.clone()).subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn merge_local_and_shared() {
     let mut res = vec![];

--- a/src/ops/merge_all.rs
+++ b/src/ops/merge_all.rs
@@ -269,6 +269,7 @@ mod test {
     );
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared() {
     let values = Arc::new(Mutex::new(vec![]));

--- a/src/ops/merge_all.rs
+++ b/src/ops/merge_all.rs
@@ -1,11 +1,10 @@
-use super::box_it::{LocalBoxOp, SharedBoxOp};
+use super::box_it::LocalBoxOp;
+#[cfg(not(target_arch = "wasm32"))]
+use super::box_it::SharedBoxOp;
 use crate::prelude::*;
-use std::{
-  cell::RefCell,
-  collections::VecDeque,
-  rc::Rc,
-  sync::{Arc, Mutex},
-};
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{Arc, Mutex};
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 pub struct MergeAllOp<S> {
   pub concurrent: usize,
@@ -129,6 +128,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<S> SharedObservable for MergeAllOp<S>
 where
   S: SharedObservable,
@@ -157,6 +157,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub struct SharedMergeAllObserver<O: Observer> {
   observer: O,
   subscribed: usize,
@@ -166,6 +167,7 @@ pub struct SharedMergeAllObserver<O: Observer> {
   buffer: VecDeque<SharedBoxOp<O::Item, O::Err>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<O> Observer for Arc<Mutex<SharedMergeAllObserver<O>>>
 where
   O: Observer + Send + Sync + 'static,
@@ -201,8 +203,10 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 struct SharedInnerObserver<O: Observer>(Arc<Mutex<SharedMergeAllObserver<O>>>);
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<O> Observer for SharedInnerObserver<O>
 where
   O: Observer + Send + Sync + 'static,

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -134,6 +134,7 @@ mod test {
     assert_eq!(*v.borrow(), 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn switch_thread() {
     let id = thread::spawn(move || {}).thread().id();
@@ -167,6 +168,7 @@ mod test {
     assert!(ot.len() > 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn pool_unsubscribe() {
     let scheduler = ThreadPool::new().unwrap();

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 use crate::scheduler::SharedScheduler;
 use crate::{impl_helper::*, impl_local_shared_both, prelude::*};
 #[derive(Clone)]
@@ -57,6 +58,7 @@ macro_rules! impl_observer {
   };
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<O, SD> Observer for ObserveOnObserver<MutArc<O>, SD, SharedSubscription>
 where
   O: Observer + Send + 'static,
@@ -104,6 +106,7 @@ macro_rules! impl_scheduler {
   };
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl_scheduler!(SharedScheduler, MutArc, SharedSubscription, Send);
 impl_scheduler!(LocalScheduler, MutRc, LocalSubscription,);
 

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -158,6 +158,7 @@ mod test {
     assert_eq!(accept2, 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     observable::of(1)

--- a/src/ops/sample.rs
+++ b/src/ops/sample.rs
@@ -163,6 +163,7 @@ mod test {
       assert_eq!(x.borrow().len(), 10);
     };
   }
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn sample_by_subject() {
     let mut subject = SharedSubject::new();

--- a/src/ops/scan.rs
+++ b/src/ops/scan.rs
@@ -61,6 +61,7 @@ where
   observable_impl!(LocalSubscription, 'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<OutputItem, Source, BinaryOp> SharedObservable
   for ScanOp<Source, BinaryOp, OutputItem>
 where

--- a/src/ops/scan.rs
+++ b/src/ops/scan.rs
@@ -147,6 +147,7 @@ mod test {
     assert_eq!(vec!(1, 2, 3, 4, 5), emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn scan_fork_and_shared_mixed_types() {
     // type to type can fork
@@ -157,6 +158,7 @@ mod test {
       .subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn scan_fork_and_shared() {
     // type to type can fork

--- a/src/ops/skip.rs
+++ b/src/ops/skip.rs
@@ -106,6 +106,7 @@ mod test {
     assert_eq!(nc2, 90);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/skip_last.rs
+++ b/src/ops/skip_last.rs
@@ -98,6 +98,7 @@ mod test {
     assert_eq!(nc2, 90);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/skip_while.rs
+++ b/src/ops/skip_while.rs
@@ -106,6 +106,7 @@ mod test {
     assert_eq!(nc2, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/skip_while.rs
+++ b/src/ops/skip_while.rs
@@ -41,6 +41,7 @@ where
   observable_impl!(LocalSubscription, S, 'a);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<S, F> SharedObservable for SkipWhileOp<S, F>
 where
   S: SharedObservable,

--- a/src/ops/subscribe_on.rs
+++ b/src/ops/subscribe_on.rs
@@ -40,6 +40,7 @@ mod test {
   use std::thread;
   use std::time::Duration;
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn thread_pool() {
     let pool = ThreadPool::new().unwrap();
@@ -61,6 +62,7 @@ mod test {
     assert_ne!(c_thread.lock().unwrap()[0], thread::current().id());
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn pool_unsubscribe() {
     let pool = ThreadPool::new().unwrap();

--- a/src/ops/take.rs
+++ b/src/ops/take.rs
@@ -96,6 +96,7 @@ mod test {
     assert_eq!(nc2, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/take_last.rs
+++ b/src/ops/take_last.rs
@@ -89,6 +89,7 @@ mod test {
     assert_eq!(nc2, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/take_until.rs
+++ b/src/ops/take_until.rs
@@ -107,6 +107,7 @@ mod test {
     assert_eq!(completed_count, 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     let last_next_arg = Arc::new(Mutex::new(None));

--- a/src/ops/take_while.rs
+++ b/src/ops/take_while.rs
@@ -117,6 +117,7 @@ mod test {
     assert_eq!(nc2, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn into_shared() {
     observable::from_iter(0..100)

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -157,6 +157,7 @@ mod tests {
     assert_eq!(&*x_c.rc_deref(), &[0, 3]);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     use futures::executor::ThreadPool;

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -118,6 +118,7 @@ macro_rules! impl_observer {
 }
 
 impl_observer!(MutRc, LocalScheduler);
+#[cfg(not(target_arch = "wasm32"))]
 impl_observer!(MutArc, SharedScheduler, Send);
 
 #[cfg(test)]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -135,6 +135,25 @@ mod futures_scheduler {
   }
 }
 
+#[cfg(target_arch = "wasm32")]
+pub struct LocalSpawner;
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-scheduler"))]
+mod wasm_scheduler {
+  use crate::scheduler::{LocalScheduler, LocalSpawner};
+  use futures::FutureExt;
+  use wasm_bindgen_futures::spawn_local;
+
+  impl LocalScheduler for LocalSpawner {
+    fn spawn<Fut>(&self, future: Fut)
+    where
+      Fut: futures::Future<Output = ()> + 'static,
+    {
+      spawn_local(future.map(|_| {}));
+    }
+  }
+}
+
 fn repeating_future(
   task: impl FnMut(usize) + 'static,
   time_between: Duration,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -18,6 +18,7 @@ pub fn task_future<T>(
 }
 
 /// A Scheduler is an object to order task and schedule their execution.
+#[cfg(not(target_arch = "wasm32"))]
 pub trait SharedScheduler {
   fn spawn<Fut>(&self, future: Fut)
   where
@@ -105,13 +106,16 @@ impl SubscriptionLike for SpawnHandle {
 
 #[cfg(feature = "futures-scheduler")]
 mod futures_scheduler {
-  use crate::scheduler::{LocalScheduler, SharedScheduler};
+  use crate::scheduler::LocalScheduler;
+  #[cfg(not(target_arch = "wasm32"))]
+  use crate::scheduler::SharedScheduler;
   use futures::{
-    executor::{LocalSpawner, ThreadPool},
-    task::{LocalSpawnExt, SpawnExt},
-    Future, FutureExt,
+    executor::LocalSpawner, task::LocalSpawnExt, Future, FutureExt,
   };
+  #[cfg(not(target_arch = "wasm32"))]
+  use futures::{executor::ThreadPool, task::SpawnExt};
 
+  #[cfg(not(target_arch = "wasm32"))]
   impl SharedScheduler for ThreadPool {
     fn spawn<Fut>(&self, future: Fut)
     where

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -271,6 +271,7 @@ mod test {
   use futures::executor::ThreadPool;
   use std::time::{Duration, Instant};
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn smoke() {
     let test_code = MutArc::own("".to_owned());
@@ -320,6 +321,7 @@ mod test {
     assert_eq!(i, 0);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn empty_local_subject_can_convert_into_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -358,6 +360,7 @@ mod test {
     local.error(2);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fix_recursive_next() {
     let mut subject = Subject::default();

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -120,6 +120,7 @@ impl<Item, Err> Observable for SharedSubject<Item, Err> {
   type Err = Err;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, Err> SharedObservable for SharedSubject<Item, Err> {
   type Unsub = MutArc<SingleSubscription>;
   fn actual_subscribe<O>(self, observer: O) -> Self::Unsub

--- a/src/subject/behavior_subject.rs
+++ b/src/subject/behavior_subject.rs
@@ -169,6 +169,7 @@ mod test {
     assert_eq!(i, 42);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn empty_local_subject_can_convert_into_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/subject/behavior_subject.rs
+++ b/src/subject/behavior_subject.rs
@@ -73,6 +73,7 @@ impl<Item, Err> Observable for SharedBehaviorSubject<Item, Err> {
   type Err = Err;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<Item, Err> SharedObservable for SharedBehaviorSubject<Item, Err>
 where
   Item: Clone,


### PR DESCRIPTION
Closes #118, #177, and #176.

All mentions of `shared` anything are behind a `#[cfg(not(target_arch = "wasm32"))], which includes most tests...which don't matter, in this case, as they aren't run by the `wasm_bindgen_test` runner anyway.