### PR TITLE
Correct minor typos and rename variables

### DIFF
--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1074,7 +1074,7 @@ pub trait Observable: Sized {
       // Note: we will never be dividing by zero here, as
       // the acc.1 will be always >= 1.
       // It would have be zero if we've would have received an element
-      // when the source observable is empty but beacuse of how
+      // when the source observable is empty but because of how
       // `scan` works, we will transparently not receive anything in
       // such case.
       acc.0 * (1.0 / (acc.1 as f64))

--- a/src/ops/default_if_empty.rs
+++ b/src/ops/default_if_empty.rs
@@ -113,14 +113,14 @@ mod test {
   #[test]
   fn bench_base() { bench_b(); }
 
-  benchmark_group!(bench_b, bench_base_funciton);
+  benchmark_group!(bench_b, bench_base_function);
 
-  fn bench_base_funciton(b: &mut Bencher) { b.iter(base_function); }
+  fn bench_base_function(b: &mut Bencher) { b.iter(base_function); }
 
   #[test]
   fn bench_empty() { bench_e(); }
 
-  benchmark_group!(bench_e, bench_empty_funciton);
+  benchmark_group!(bench_e, bench_empty_function);
 
-  fn bench_empty_funciton(b: &mut Bencher) { b.iter(base_empty_function); }
+  fn bench_empty_function(b: &mut Bencher) { b.iter(base_empty_function); }
 }

--- a/src/ops/group_by.rs
+++ b/src/ops/group_by.rs
@@ -31,7 +31,7 @@ where
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/// Observable emited by the GroupByOp.
+/// Observable emitted by the GroupByOp.
 #[derive(Clone)]
 pub struct GroupObservable<Source, Discr, Key> {
   source: Source,

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -138,7 +138,7 @@ mod test {
     let c_changed_thread = changed_thread.clone();
     let emit_thread = Arc::new(Mutex::new(id));
     let observe_thread = Arc::new(Mutex::new(HashSet::new()));
-    let oc = observe_thread.clone();
+    let thread_clone = observe_thread.clone();
 
     let pool = ThreadPool::builder().pool_size(100).create().unwrap();
 
@@ -152,16 +152,16 @@ mod test {
     .observe_on(pool)
     .into_shared()
     .subscribe_blocking(move |_v| {
-      let mut ot = observe_thread.lock().unwrap();
-      ot.insert(thread::current().id());
+      let mut thread = observe_thread.lock().unwrap();
+      thread.insert(thread::current().id());
 
-      c_changed_thread.store(ot.len() > 1, Ordering::Relaxed);
+      c_changed_thread.store(thread.len() > 1, Ordering::Relaxed);
     });
 
     let current_id = thread::current().id();
     assert_eq!(*emit_thread.lock().unwrap(), current_id);
-    let ot = oc.lock().unwrap();
-    assert!(ot.len() > 1);
+    let thread = thread_clone.lock().unwrap();
+    assert!(thread.len() > 1);
   }
 
   #[test]

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -17,9 +17,9 @@ pub trait TearDownSize: SubscriptionLike {
 
 impl<S: SubscriptionLike + ?Sized> SubscriptionLike for Box<S> {
   #[inline]
-  fn unsubscribe(&mut self) { (&mut **self).unsubscribe() }
+  fn unsubscribe(&mut self) { (**self).unsubscribe() }
   #[inline]
-  fn is_closed(&self) -> bool { (&**self).is_closed() }
+  fn is_closed(&self) -> bool { (**self).is_closed() }
 }
 
 pub type SharedSubscription =


### PR DESCRIPTION
This revision includes:
- Correct minor typos
- Rename variables for improving readability