### PR TITLE
Use buffer for Rc to avoid `already borrow` issue

### DIFF
--- a/src/impl_helper.rs
+++ b/src/impl_helper.rs
@@ -290,6 +290,7 @@ pub mod impl_local {
 
   pub type RcMultiSubscription = LocalSubscription;
   pub type Rc<T> = MutRc<T>;
+  pub type Brc<T, Item, Err> = BufferedMutRc<T, Item, Err>;
   pub trait Scheduler: LocalScheduler {}
   impl<T: LocalScheduler> Scheduler for T {}
 
@@ -314,6 +315,7 @@ pub mod impl_shared {
 
   pub type RcMultiSubscription = SharedSubscription;
   pub type Rc<T> = MutArc<T>;
+  pub type Brc<T, Item, Err> = BufferedMutArc<T, Item, Err>;
   pub trait Scheduler: SharedScheduler {}
   impl<T: SharedScheduler> Scheduler for T {}
 

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+use std::borrow::BorrowMut;
+use std::ops::DerefMut;
 use std::{
   cell::{BorrowError, BorrowMutError, Ref, RefCell, RefMut},
   rc::Rc,
@@ -42,12 +44,27 @@ pub struct MutRc<T>(Rc<RefCell<T>>);
 #[derive(Default)]
 pub struct MutArc<T>(Arc<Mutex<T>>);
 
+#[derive(Default)]
+pub struct BufferedMutRc<T, Item, Err> {
+  inner: Rc<RefCell<T>>,
+  buffer: Rc<RefCell<Vec<ObserverTrigger<Item, Err>>>>,
+}
+
 impl<T> MutArc<T> {
   pub fn own(t: T) -> Self { Self(Arc::new(Mutex::new(t))) }
 }
 
 impl<T> MutRc<T> {
   pub fn own(t: T) -> Self { Self(Rc::new(RefCell::new(t))) }
+}
+
+impl<T, Item, Err> BufferedMutRc<T, Item, Err> {
+  pub fn own(t: T) -> Self {
+    Self {
+      inner: Rc::new(RefCell::new(t)),
+      buffer: Rc::new(RefCell::new(Vec::new())),
+    }
+  }
 }
 
 impl<T> RcDeref for MutRc<T> {
@@ -92,6 +109,26 @@ impl<T> TryRcDeref for MutArc<T> {
   fn try_rc_deref<'a>(&'a self) -> Self::Target<'a> { self.0.try_lock() }
 }
 
+impl<T, Item, Err> RcDeref for BufferedMutRc<T, Item, Err> {
+  type Target<'a>
+  where
+    Self: 'a,
+  = Ref<'a, T>;
+  #[inline]
+  #[allow(clippy::needless_lifetimes)]
+  fn rc_deref<'a>(&'a self) -> Self::Target<'a> { self.inner.borrow() }
+}
+
+impl<T, Item, Err> TryRcDeref for BufferedMutRc<T, Item, Err> {
+  type Target<'a>
+  where
+    Self: 'a,
+  = Result<Ref<'a, T>, BorrowError>;
+  #[inline]
+  #[allow(clippy::needless_lifetimes)]
+  fn try_rc_deref<'a>(&'a self) -> Self::Target<'a> { self.inner.try_borrow() }
+}
+
 impl<T> RcDerefMut for MutRc<T> {
   type Target<'a>
   where
@@ -100,7 +137,7 @@ impl<T> RcDerefMut for MutRc<T> {
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
-  fn rc_deref_mut<'a>(&'a self) -> Self::Target<'a> { self.0.borrow_mut() }
+  fn rc_deref_mut<'a>(&'a self) -> Self::Target<'a> { (*self.0).borrow_mut() }
 }
 
 impl<T> RcDerefMut for MutArc<T> {
@@ -112,6 +149,19 @@ impl<T> RcDerefMut for MutArc<T> {
   #[inline]
   #[allow(clippy::needless_lifetimes)]
   fn rc_deref_mut<'a>(&'a self) -> Self::Target<'a> { self.0.lock().unwrap() }
+}
+
+impl<T, Item, Err> RcDerefMut for BufferedMutRc<T, Item, Err> {
+  type Target<'a>
+  where
+    Self: 'a,
+  = RefMut<'a, T>;
+
+  #[inline]
+  #[allow(clippy::needless_lifetimes)]
+  fn rc_deref_mut<'a>(&'a self) -> Self::Target<'a> {
+    (*self.inner).borrow_mut()
+  }
 }
 
 impl<T> TryRcDerefMut for MutRc<T> {
@@ -138,6 +188,19 @@ impl<T> TryRcDerefMut for MutArc<T> {
   fn try_rc_deref_mut<'a>(&'a self) -> Self::Target<'a> { self.0.try_lock() }
 }
 
+impl<T, Item, Err> TryRcDerefMut for BufferedMutRc<T, Item, Err> {
+  type Target<'a>
+  where
+    Self: 'a,
+  = Result<RefMut<'a, T>, BorrowMutError>;
+
+  #[inline]
+  #[allow(clippy::needless_lifetimes)]
+  fn try_rc_deref_mut<'a>(&'a self) -> Self::Target<'a> {
+    self.inner.try_borrow_mut()
+  }
+}
+
 macro_rules! observer_impl {
   ($rc: ident) => {
     impl<T> Observer for $rc<T>
@@ -156,6 +219,84 @@ macro_rules! observer_impl {
 observer_impl!(MutArc);
 observer_impl!(MutRc);
 
+// impl<T, Item, Err> BufferedMutRc<T, Item, Err>
+// where
+//   T: Observer<Item = Item, Err = Err>,
+// {
+//   pub fn emit_buffer(&self) {
+//     let mut observer = self.rc_deref_mut();
+//     loop {
+//       let v = (*self.buffer).borrow_mut().pop();
+//       if let Some(to_emit) = v {
+//         match to_emit {
+//           ObserverTrigger::Item(v) => observer.next(v),
+//           ObserverTrigger::Err(err) => observer.error(err),
+//           ObserverTrigger::Complete => observer.complete(),
+//         }
+//       } else {
+//         break;
+//       }
+//     }
+//   }
+// }
+
+fn emit_buffer<'a, O, Item, Err>(
+  mut observer: O,
+  b: &'a mut Vec<ObserverTrigger<Item, Err>>,
+) where
+  O: DerefMut,
+  O::Target: Observer<Item = Item, Err = Err>,
+{
+  loop {
+    let v = b.pop();
+    if let Some(to_emit) = v {
+      match to_emit {
+        ObserverTrigger::Item(v) => observer.next(v),
+        ObserverTrigger::Err(err) => observer.error(err),
+        ObserverTrigger::Complete => observer.complete(),
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+impl<T, Item, Err> Observer for BufferedMutRc<T, Item, Err>
+where
+  T: Observer<Item = Item, Err = Err>,
+{
+  type Item = Item;
+  type Err = Err;
+  fn next(&mut self, value: Self::Item) {
+    if let Ok(mut inner) = self.try_rc_deref_mut() {
+      inner.next(value);
+      emit_buffer(inner, &mut (*self.buffer).borrow_mut());
+    } else {
+      (*self.buffer)
+        .borrow_mut()
+        .push(ObserverTrigger::Item(value));
+    }
+  }
+
+  fn error(&mut self, err: Self::Err) {
+    if let Ok(mut inner) = self.try_rc_deref_mut() {
+      inner.error(err);
+      emit_buffer(inner, &mut (*self.buffer).borrow_mut());
+    } else {
+      (*self.buffer).borrow_mut().push(ObserverTrigger::Err(err));
+    }
+  }
+
+  fn complete(&mut self) {
+    if let Ok(mut inner) = self.try_rc_deref_mut() {
+      inner.complete();
+      emit_buffer(inner, &mut (*self.buffer).borrow_mut());
+    } else {
+      (*self.buffer).borrow_mut().push(ObserverTrigger::Complete);
+    }
+  }
+}
+
 macro_rules! rc_subscription_impl {
   ($rc: ident) => {
     impl<T: SubscriptionLike> SubscriptionLike for $rc<T> {
@@ -171,6 +312,16 @@ macro_rules! rc_subscription_impl {
 rc_subscription_impl!(MutArc);
 rc_subscription_impl!(MutRc);
 
+impl<T: SubscriptionLike, Item, Err> SubscriptionLike
+  for BufferedMutRc<T, Item, Err>
+{
+  #[inline]
+  fn unsubscribe(&mut self) { self.rc_deref_mut().unsubscribe() }
+
+  #[inline]
+  fn is_closed(&self) -> bool { self.rc_deref().is_closed() }
+}
+
 impl<T> Clone for MutRc<T> {
   #[inline]
   fn clone(&self) -> Self { Self(self.0.clone()) }
@@ -179,6 +330,16 @@ impl<T> Clone for MutRc<T> {
 impl<T> Clone for MutArc<T> {
   #[inline]
   fn clone(&self) -> Self { Self(self.0.clone()) }
+}
+
+impl<T, Item, Err> Clone for BufferedMutRc<T, Item, Err> {
+  #[inline]
+  fn clone(&self) -> Self {
+    Self {
+      inner: Rc::clone(&self.inner),
+      buffer: Rc::clone(&self.buffer),
+    }
+  }
 }
 
 macro_rules! impl_teardown_size {
@@ -191,3 +352,8 @@ macro_rules! impl_teardown_size {
 }
 impl_teardown_size!(MutRc);
 impl_teardown_size!(MutArc);
+
+impl<T: TearDownSize, Item, Err> TearDownSize for BufferedMutRc<T, Item, Err> {
+  #[inline]
+  fn teardown_size(&self) -> usize { self.inner.borrow().teardown_size() }
+}


### PR DESCRIPTION
### Current Status

Motivating example for this problem is `ops::take_until::test::circular_next`. It fails with `already borrowed` error.

This happens because 
1. we get first reference of `main_observer`(which is `MutRc<O>`) while calling callback function for 'next'
2. when we try to call next on notifier, it tries to call complete on main_observer internally, which leads to getting second reference of `main_observer`. 
3. so `already borrow` is raised.

### Suggested Solution

I borrowed the idea of having buffer for next item from the implementation of subject.
Even though I think this is a bit ugly solution, ragarding DRY princible, but I couldn't came up with better idea for now.