### PR TITLE
Support `wasm` build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,26 @@ jobs:
           command: test
           args: --all-features
 
+  test-wasm:
+    name: wasm Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Run wasm-pack test
+        run: wasm-pack test --node
+
   rustfmt:
     name: rust code format style check
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ version = "1.6.3"
 features = ["unstable"]
 
 [dependencies.futures]
-version="0.3.5"
-features= ["thread-pool"]
+version = "0.3.5"
+features = ["thread-pool"]
 
 [dependencies.tokio]
 version = "1.0"
@@ -36,7 +36,7 @@ version = "0.4.29"
 optional = true
 
 [features]
-default = []
+default = ["futures-scheduler"]
 tokio-scheduler = ["tokio"]
 futures-scheduler = []
 wasm-scheduler = ["wasm-bindgen-futures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,15 @@ version = "1.0"
 features = ["rt-multi-thread", "rt"]
 optional = true
 
+[dependencies.wasm-bindgen-futures]
+version = "0.4.29"
+optional = true
+
 [features]
-default = ["futures-scheduler"]
+default = []
 tokio-scheduler = ["tokio"]
 futures-scheduler = []
+wasm-scheduler = ["wasm-bindgen-futures"]
 
 [dev-dependencies]
 float-cmp = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ wasm-scheduler = ["wasm-bindgen-futures"]
 [dev-dependencies]
 float-cmp = "0.8.0"
 bencher = "0.1.5"
+wasm-bindgen-test = "0.3.29"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ observable::from_iter(0..10)
   .subscribe(|v| {println!("{},", v)});
 ```
 
+Also, `rxrust` supports WebAssembly by enabling the feature `wasm-scheduler` and using the crate `wasm-bindgen`. Simple example is [here](https://github.com/utilForever/rxrust-with-wasm). Note that `wasm-scheduler` only supports `LocalScheduler`.
+
 ## Converts from a Future
 
 Just use `observable::from_future` to convert a `Future` to an observable sequence.

--- a/src/impl_helper.rs
+++ b/src/impl_helper.rs
@@ -276,7 +276,7 @@ macro_rules! impl_local_shared_both {
   // enter replace
   ($($t:tt)*) => {
     impl_local_shared_both!(@replace, impl_local, [] $($t)*);
-    #[cfg(not(feature = "wasm-scheduler"))]
+    #[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
     impl_local_shared_both!(@replace, impl_shared, [] $($t)*);
   };
 }
@@ -305,7 +305,7 @@ pub mod impl_local {
   }
 }
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 pub mod impl_shared {
   use crate::prelude::*;
   // macro builtin replace.

--- a/src/impl_helper.rs
+++ b/src/impl_helper.rs
@@ -276,7 +276,7 @@ macro_rules! impl_local_shared_both {
   // enter replace
   ($($t:tt)*) => {
     impl_local_shared_both!(@replace, impl_local, [] $($t)*);
-    #[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+    #[cfg(not(all(target_arch = "wasm32")))]
     impl_local_shared_both!(@replace, impl_shared, [] $($t)*);
   };
 }
@@ -305,7 +305,7 @@ pub mod impl_local {
   }
 }
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 pub mod impl_shared {
   use crate::prelude::*;
   // macro builtin replace.

--- a/src/impl_helper.rs
+++ b/src/impl_helper.rs
@@ -276,6 +276,7 @@ macro_rules! impl_local_shared_both {
   // enter replace
   ($($t:tt)*) => {
     impl_local_shared_both!(@replace, impl_local, [] $($t)*);
+    #[cfg(not(feature = "wasm-scheduler"))]
     impl_local_shared_both!(@replace, impl_shared, [] $($t)*);
   };
 }
@@ -304,6 +305,7 @@ pub mod impl_local {
   }
 }
 
+#[cfg(not(feature = "wasm-scheduler"))]
 pub mod impl_shared {
   use crate::prelude::*;
   // macro builtin replace.

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1659,6 +1659,7 @@ mod tests {
     b.iter(smoke_ignore_elements);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared_ignore_elements() {
     observable::from_iter(0..20)

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -147,6 +147,7 @@ mod test {
     assert_eq!(second, 100);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     let o = observable::of(100);

--- a/src/observable/defer.rs
+++ b/src/observable/defer.rs
@@ -44,6 +44,7 @@ impl_local_shared_both! {
  where F: FnOnce()-> U, U: @ctx::Observable
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod test {
   use std::ops::Deref;

--- a/src/observable/from_fn.rs
+++ b/src/observable/from_fn.rs
@@ -30,6 +30,7 @@ impl_local_shared_both! {
   where F: FnOnce(&mut dyn Observer<Item = Item, Err = Err>)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod test {
   use crate::prelude::*;

--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -120,15 +120,12 @@ impl_local_shared_both! {
 mod tests {
   use super::*;
   use bencher::Bencher;
-  use futures::{
-    executor::{LocalPool, ThreadPool},
-    future,
-  };
-  use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::{Arc, Mutex},
-  };
+  #[cfg(not(target_arch = "wasm32"))]
+  use futures::executor::ThreadPool;
+  use futures::{executor::LocalPool, future};
+  #[cfg(not(target_arch = "wasm32"))]
+  use std::sync::{Arc, Mutex};
+  use std::{cell::RefCell, rc::Rc};
 
   #[cfg(not(target_arch = "wasm32"))]
   #[test]

--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -130,6 +130,7 @@ mod tests {
     sync::{Arc, Mutex},
   };
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared() {
     let res = Arc::new(Mutex::new(0));

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -60,6 +60,7 @@ mod tests {
   use futures::executor::{LocalPool, ThreadPool};
   use std::sync::{Arc, Mutex};
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared() {
     let millis = Arc::new(Mutex::new(0));

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -57,7 +57,9 @@ impl_local_shared_both! {
 mod tests {
   use super::*;
   use crate::test_scheduler::ManualScheduler;
-  use futures::executor::{LocalPool, ThreadPool};
+  use futures::executor::LocalPool;
+  #[cfg(not(target_arch = "wasm32"))]
+  use futures::executor::ThreadPool;
   use std::sync::{Arc, Mutex};
 
   #[cfg(not(target_arch = "wasm32"))]

--- a/src/observable/observable_block.rs
+++ b/src/observable/observable_block.rs
@@ -86,6 +86,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod test {
   use crate::prelude::*;
@@ -93,7 +94,6 @@ mod test {
   use std::sync::{Arc, Mutex};
   use std::time::{Duration, Instant};
 
-  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn blocks_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/observable/observable_block.rs
+++ b/src/observable/observable_block.rs
@@ -93,6 +93,7 @@ mod test {
   use std::sync::{Arc, Mutex};
   use std::time::{Duration, Instant};
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn blocks_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/observable/observable_block_all.rs
+++ b/src/observable/observable_block_all.rs
@@ -111,6 +111,7 @@ where
   }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod test {
   use crate::prelude::*;
@@ -118,7 +119,6 @@ mod test {
   use std::sync::{Arc, Mutex};
   use std::time::{Duration, Instant};
 
-  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn blocks_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/observable/observable_block_all.rs
+++ b/src/observable/observable_block_all.rs
@@ -118,6 +118,7 @@ mod test {
   use std::sync::{Arc, Mutex};
   use std::time::{Duration, Instant};
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn blocks_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/observable/start.rs
+++ b/src/observable/start.rs
@@ -49,6 +49,7 @@ mod tests {
     assert!(is_completed);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_emit_closure_value_shared() {
     let actual = Arc::new(AtomicI32::new(0));

--- a/src/observable/start.rs
+++ b/src/observable/start.rs
@@ -31,7 +31,9 @@ impl_local_shared_both! {
 #[cfg(test)]
 mod tests {
   use crate::prelude::*;
+  #[cfg(not(target_arch = "wasm32"))]
   use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+  #[cfg(not(target_arch = "wasm32"))]
   use std::sync::Arc;
 
   #[test]

--- a/src/observable/timer.rs
+++ b/src/observable/timer.rs
@@ -102,6 +102,7 @@ mod tests {
     assert_eq!(val, i_emitted.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_shall_emit_value_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -137,6 +138,7 @@ mod tests {
     assert_eq!(next_count.load(Ordering::Relaxed), 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_shall_call_next_once_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -174,6 +176,7 @@ mod tests {
     assert!(is_completed.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_shall_be_completed_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -208,6 +211,7 @@ mod tests {
     assert!(stamp.elapsed() >= duration);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_shall_elapse_duration_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -244,6 +248,7 @@ mod tests {
     assert_eq!(val, i_emitted.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn timer_at_shall_emit_value_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/observable/timer.rs
+++ b/src/observable/timer.rs
@@ -79,7 +79,9 @@ impl_local_shared_both! {
 #[cfg(test)]
 mod tests {
   use crate::prelude::*;
-  use futures::executor::{LocalPool, ThreadPool};
+  use futures::executor::LocalPool;
+  #[cfg(not(target_arch = "wasm32"))]
+  use futures::executor::ThreadPool;
   use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
   use std::sync::Arc;
   use std::time::{Duration, Instant};

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -141,6 +141,7 @@ mod test {
     assert_eq!(6, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn reduce_fork_and_shared() {
     // type to type can fork
@@ -220,8 +221,8 @@ mod test {
     assert_eq!(None, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
-
   fn max_fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(vec![1., 2.]).max();
@@ -295,8 +296,8 @@ mod test {
     assert_eq!(None, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
-
   fn min_fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(vec![1., 2.]).min();
@@ -335,6 +336,7 @@ mod test {
     assert_eq!(-1, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn sum_fork_and_shared() {
     // type to type can fork
@@ -360,6 +362,7 @@ mod test {
     assert_eq!(0, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn count_fork_and_shared() {
     // type to type can fork
@@ -435,6 +438,7 @@ mod test {
     assert_eq!(None, emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn average_fork_and_shared() {
     // type to type can fork

--- a/src/ops/box_it.rs
+++ b/src/ops/box_it.rs
@@ -213,6 +213,7 @@ where
   fn box_it(origin: T) -> BoxOp<Self> { BoxOp(Box::new(origin)) }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod test {
   use crate::prelude::*;

--- a/src/ops/buffer.rs
+++ b/src/ops/buffer.rs
@@ -276,6 +276,7 @@ mod tests {
     assert_eq!(expected, actual);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_buffer_with_count_shared() {
     let expected =
@@ -373,6 +374,7 @@ mod tests {
     local.run();
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_buffer_with_time_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -411,6 +413,7 @@ mod tests {
     assert!(is_completed.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_not_emit_buffer_with_time_on_error() {
     let pool = ThreadPool::new().unwrap();
@@ -501,6 +504,7 @@ mod tests {
     assert!(error_called.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_buffer_with_count_or_time_shared() {
     let pool = ThreadPool::new().unwrap();
@@ -537,6 +541,7 @@ mod tests {
     assert!(is_completed.load(Ordering::Relaxed));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn it_shall_buffer_with_count_or_time_shared_on_error() {
     let pool = ThreadPool::new().unwrap();

--- a/src/ops/buffer.rs
+++ b/src/ops/buffer.rs
@@ -257,10 +257,13 @@ where
 #[cfg(test)]
 mod tests {
   use crate::prelude::*;
-  use futures::executor::{LocalPool, ThreadPool};
+  use futures::executor::LocalPool;
+  #[cfg(not(target_arch = "wasm32"))]
+  use futures::executor::ThreadPool;
   use std::cell::RefCell;
   use std::rc::Rc;
   use std::sync::atomic::{AtomicBool, Ordering};
+  #[cfg(not(target_arch = "wasm32"))]
   use std::sync::{Arc, Mutex};
   use std::time::Duration;
 

--- a/src/ops/contains.rs
+++ b/src/ops/contains.rs
@@ -94,6 +94,7 @@ mod test {
     observable::empty().contains(1).subscribe(|b| assert!(!b));
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn contains_shared() {
     observable::from_iter(0..10)

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -95,7 +95,7 @@ macro_rules! impl_observer {
 }
 
 impl_observer!(MutRc, LocalScheduler);
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 impl_observer!(MutArc, SharedScheduler, Send);
 #[cfg(test)]
 mod tests {

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -95,7 +95,7 @@ macro_rules! impl_observer {
 }
 
 impl_observer!(MutRc, LocalScheduler);
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 impl_observer!(MutArc, SharedScheduler, Send);
 #[cfg(test)]
 mod tests {
@@ -145,6 +145,7 @@ mod tests {
     assert_eq!(&*x_c.rc_deref(), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     use futures::executor::ThreadPool;

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -95,6 +95,7 @@ macro_rules! impl_observer {
 }
 
 impl_observer!(MutRc, LocalScheduler);
+#[cfg(not(feature = "wasm-scheduler"))]
 impl_observer!(MutArc, SharedScheduler, Send);
 #[cfg(test)]
 mod tests {

--- a/src/ops/default_if_empty.rs
+++ b/src/ops/default_if_empty.rs
@@ -94,6 +94,7 @@ mod test {
     assert!(completed);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn into_shared() {
     observable::from_iter(0..100)
@@ -102,6 +103,7 @@ mod test {
       .subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared_empty() {
     observable::empty()

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -47,6 +47,7 @@ mod tests {
     sync::{Arc, Mutex},
   };
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared_smoke() {
     let value = Arc::new(Mutex::new(0));

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -39,13 +39,13 @@ impl_local_shared_both! {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use futures::executor::{LocalPool, ThreadPool};
+  use futures::executor::LocalPool;
+  #[cfg(not(target_arch = "wasm32"))]
+  use futures::executor::ThreadPool;
+  #[cfg(not(target_arch = "wasm32"))]
+  use std::sync::{Arc, Mutex};
   use std::time::Instant;
-  use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::{Arc, Mutex},
-  };
+  use std::{cell::RefCell, rc::Rc};
 
   #[cfg(not(target_arch = "wasm32"))]
   #[test]

--- a/src/ops/distinct.rs
+++ b/src/ops/distinct.rs
@@ -233,6 +233,8 @@ mod tests {
       .unsubscribe();
     assert_eq!(&*x_c.borrow(), &[0, 1, 2, 3, 4]);
   }
+
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn shared() {
     observable::from_iter(0..10)
@@ -241,6 +243,7 @@ mod tests {
       .into_shared()
       .subscribe(|_| {});
   }
+
   #[test]
   fn bench() { do_bench(); }
 
@@ -259,6 +262,8 @@ mod tests {
       .unsubscribe();
     assert_eq!(&*x_c.borrow(), &[1, 2, 1, 2, 3]);
   }
+
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn distinct_until_changed_shared() {
     observable::from_iter(0..10)

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -76,6 +76,7 @@ where
 mod test {
   use crate::prelude::*;
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     observable::from_iter(0..10)

--- a/src/ops/filter_map.rs
+++ b/src/ops/filter_map.rs
@@ -89,6 +89,7 @@ mod test {
     assert_eq!(i, 3);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn filter_map_shared_and_fork() {
     observable::of(1)
@@ -98,6 +99,7 @@ mod test {
       .subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn filter_map_return_ref() {
     observable::of(&1)

--- a/src/ops/flatten.rs
+++ b/src/ops/flatten.rs
@@ -363,6 +363,7 @@ mod test {
     assert_eq!(*ec.lock().unwrap(), 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn flatten_local_and_shared() {
     let mut res = vec![];

--- a/src/ops/group_by.rs
+++ b/src/ops/group_by.rs
@@ -213,6 +213,7 @@ mod test {
     assert_eq!(obs_count, 2);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn group_by_shared() {
     let s = observable::of(0).group_by(|_| "zero");

--- a/src/ops/last.rs
+++ b/src/ops/last.rs
@@ -175,6 +175,7 @@ mod test {
     assert_eq!(default, 100);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn last_fork_and_shared() {
     observable::of(0)

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -75,6 +75,7 @@ mod test {
     assert_eq!(i, 100);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     // type to type can fork

--- a/src/ops/map_to.rs
+++ b/src/ops/map_to.rs
@@ -94,6 +94,7 @@ mod test {
     assert_eq!(i, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     // type to type can fork

--- a/src/ops/merge.rs
+++ b/src/ops/merge.rs
@@ -180,6 +180,7 @@ mod test {
     m.clone().merge(m.clone()).subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn merge_local_and_shared() {
     let mut res = vec![];

--- a/src/ops/merge_all.rs
+++ b/src/ops/merge_all.rs
@@ -1,11 +1,14 @@
-use super::box_it::{LocalBoxOp, SharedBoxOp};
+use super::box_it::LocalBoxOp;
+#[cfg(not(feature = "wasm-scheduler"))]
+use super::box_it::SharedBoxOp;
 use crate::prelude::*;
 use std::{
   cell::RefCell,
   collections::VecDeque,
   rc::Rc,
-  sync::{Arc, Mutex},
 };
+#[cfg(not(feature = "wasm-scheduler"))]
+use std::sync::{Arc, Mutex};
 
 pub struct MergeAllOp<S> {
   pub concurrent: usize,
@@ -129,6 +132,7 @@ where
   }
 }
 
+#[cfg(not(feature = "wasm-scheduler"))]
 impl<S> SharedObservable for MergeAllOp<S>
 where
   S: SharedObservable,
@@ -157,6 +161,7 @@ where
   }
 }
 
+#[cfg(not(feature = "wasm-scheduler"))]
 pub struct SharedMergeAllObserver<O: Observer> {
   observer: O,
   subscribed: usize,
@@ -166,6 +171,7 @@ pub struct SharedMergeAllObserver<O: Observer> {
   buffer: VecDeque<SharedBoxOp<O::Item, O::Err>>,
 }
 
+#[cfg(not(feature = "wasm-scheduler"))]
 impl<O> Observer for Arc<Mutex<SharedMergeAllObserver<O>>>
 where
   O: Observer + Send + Sync + 'static,
@@ -201,8 +207,10 @@ where
   }
 }
 
+#[cfg(not(feature = "wasm-scheduler"))]
 struct SharedInnerObserver<O: Observer>(Arc<Mutex<SharedMergeAllObserver<O>>>);
 
+#[cfg(not(feature = "wasm-scheduler"))]
 impl<O> Observer for SharedInnerObserver<O>
 where
   O: Observer + Send + Sync + 'static,
@@ -265,6 +273,7 @@ mod test {
     );
   }
 
+  #[cfg(not(feature = "wasm-scheduler"))]
   #[test]
   fn shared() {
     let values = Arc::new(Mutex::new(vec![]));

--- a/src/ops/merge_all.rs
+++ b/src/ops/merge_all.rs
@@ -1,8 +1,8 @@
 use super::box_it::LocalBoxOp;
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 use super::box_it::SharedBoxOp;
 use crate::prelude::*;
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 use std::sync::{Arc, Mutex};
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
@@ -128,7 +128,7 @@ where
   }
 }
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 impl<S> SharedObservable for MergeAllOp<S>
 where
   S: SharedObservable,
@@ -157,7 +157,7 @@ where
   }
 }
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 pub struct SharedMergeAllObserver<O: Observer> {
   observer: O,
   subscribed: usize,
@@ -167,7 +167,7 @@ pub struct SharedMergeAllObserver<O: Observer> {
   buffer: VecDeque<SharedBoxOp<O::Item, O::Err>>,
 }
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 impl<O> Observer for Arc<Mutex<SharedMergeAllObserver<O>>>
 where
   O: Observer + Send + Sync + 'static,
@@ -203,10 +203,10 @@ where
   }
 }
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 struct SharedInnerObserver<O: Observer>(Arc<Mutex<SharedMergeAllObserver<O>>>);
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 impl<O> Observer for SharedInnerObserver<O>
 where
   O: Observer + Send + Sync + 'static,
@@ -269,7 +269,7 @@ mod test {
     );
   }
 
-  #[cfg(not(feature = "wasm-scheduler"))]
+  #[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
   #[test]
   fn shared() {
     let values = Arc::new(Mutex::new(vec![]));

--- a/src/ops/merge_all.rs
+++ b/src/ops/merge_all.rs
@@ -1,8 +1,8 @@
 use super::box_it::LocalBoxOp;
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 use super::box_it::SharedBoxOp;
 use crate::prelude::*;
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 use std::sync::{Arc, Mutex};
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
@@ -128,7 +128,7 @@ where
   }
 }
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 impl<S> SharedObservable for MergeAllOp<S>
 where
   S: SharedObservable,
@@ -157,7 +157,7 @@ where
   }
 }
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 pub struct SharedMergeAllObserver<O: Observer> {
   observer: O,
   subscribed: usize,
@@ -167,7 +167,7 @@ pub struct SharedMergeAllObserver<O: Observer> {
   buffer: VecDeque<SharedBoxOp<O::Item, O::Err>>,
 }
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 impl<O> Observer for Arc<Mutex<SharedMergeAllObserver<O>>>
 where
   O: Observer + Send + Sync + 'static,
@@ -203,10 +203,10 @@ where
   }
 }
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 struct SharedInnerObserver<O: Observer>(Arc<Mutex<SharedMergeAllObserver<O>>>);
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 impl<O> Observer for SharedInnerObserver<O>
 where
   O: Observer + Send + Sync + 'static,
@@ -269,7 +269,7 @@ mod test {
     );
   }
 
-  #[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+  #[cfg(not(all(target_arch = "wasm32")))]
   #[test]
   fn shared() {
     let values = Arc::new(Mutex::new(vec![]));

--- a/src/ops/merge_all.rs
+++ b/src/ops/merge_all.rs
@@ -245,8 +245,11 @@ where
 #[cfg(test)]
 mod test {
   use super::*;
+  #[cfg(not(target_arch = "wasm32"))]
   use crate::observable::SubscribeBlocking;
-  use futures::executor::{LocalPool, ThreadPool};
+  use futures::executor::LocalPool;
+  #[cfg(not(target_arch = "wasm32"))]
+  use futures::executor::ThreadPool;
   use std::time::Duration;
 
   #[test]

--- a/src/ops/merge_all.rs
+++ b/src/ops/merge_all.rs
@@ -2,13 +2,9 @@ use super::box_it::LocalBoxOp;
 #[cfg(not(feature = "wasm-scheduler"))]
 use super::box_it::SharedBoxOp;
 use crate::prelude::*;
-use std::{
-  cell::RefCell,
-  collections::VecDeque,
-  rc::Rc,
-};
 #[cfg(not(feature = "wasm-scheduler"))]
 use std::sync::{Arc, Mutex};
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 pub struct MergeAllOp<S> {
   pub concurrent: usize,

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 use crate::scheduler::SharedScheduler;
 use crate::{impl_helper::*, impl_local_shared_both, prelude::*};
 #[derive(Clone)]
@@ -58,7 +58,7 @@ macro_rules! impl_observer {
   };
 }
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 impl<O, SD> Observer for ObserveOnObserver<MutArc<O>, SD, SharedSubscription>
 where
   O: Observer + Send + 'static,
@@ -106,7 +106,7 @@ macro_rules! impl_scheduler {
   };
 }
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 impl_scheduler!(SharedScheduler, MutArc, SharedSubscription, Send);
 impl_scheduler!(LocalScheduler, MutRc, LocalSubscription,);
 

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -113,11 +113,18 @@ impl_scheduler!(LocalScheduler, MutRc, LocalSubscription,);
 #[cfg(test)]
 mod test {
   use crate::prelude::*;
-  use futures::executor::{LocalPool, ThreadPool};
+  use futures::executor::LocalPool;
+  #[cfg(not(target_arch = "wasm32"))]
+  use futures::executor::ThreadPool;
+  #[cfg(not(target_arch = "wasm32"))]
   use std::collections::HashSet;
+  #[cfg(not(target_arch = "wasm32"))]
   use std::sync::atomic::{AtomicBool, Ordering};
+  #[cfg(not(target_arch = "wasm32"))]
   use std::sync::{Arc, Mutex};
+  #[cfg(not(target_arch = "wasm32"))]
   use std::thread;
+  #[cfg(not(target_arch = "wasm32"))]
   use std::time::Duration;
   use std::{cell::RefCell, rc::Rc};
 

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -1,4 +1,4 @@
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 use crate::scheduler::SharedScheduler;
 use crate::{impl_helper::*, impl_local_shared_both, prelude::*};
 #[derive(Clone)]
@@ -58,7 +58,7 @@ macro_rules! impl_observer {
   };
 }
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 impl<O, SD> Observer for ObserveOnObserver<MutArc<O>, SD, SharedSubscription>
 where
   O: Observer + Send + 'static,
@@ -106,7 +106,7 @@ macro_rules! impl_scheduler {
   };
 }
 
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 impl_scheduler!(SharedScheduler, MutArc, SharedSubscription, Send);
 impl_scheduler!(LocalScheduler, MutRc, LocalSubscription,);
 
@@ -134,6 +134,7 @@ mod test {
     assert_eq!(*v.borrow(), 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn switch_thread() {
     let id = thread::spawn(move || {}).thread().id();
@@ -167,6 +168,7 @@ mod test {
     assert!(thread.len() > 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn pool_unsubscribe() {
     let scheduler = ThreadPool::new().unwrap();

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "wasm-scheduler"))]
 use crate::scheduler::SharedScheduler;
 use crate::{impl_helper::*, impl_local_shared_both, prelude::*};
 #[derive(Clone)]
@@ -57,6 +58,7 @@ macro_rules! impl_observer {
   };
 }
 
+#[cfg(not(feature = "wasm-scheduler"))]
 impl<O, SD> Observer for ObserveOnObserver<MutArc<O>, SD, SharedSubscription>
 where
   O: Observer + Send + 'static,
@@ -104,6 +106,7 @@ macro_rules! impl_scheduler {
   };
 }
 
+#[cfg(not(feature = "wasm-scheduler"))]
 impl_scheduler!(SharedScheduler, MutArc, SharedSubscription, Send);
 impl_scheduler!(LocalScheduler, MutRc, LocalSubscription,);
 

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -158,6 +158,7 @@ mod test {
     assert_eq!(accept2, 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     observable::of(1)

--- a/src/ops/sample.rs
+++ b/src/ops/sample.rs
@@ -133,12 +133,9 @@ where
 mod test {
   use crate::prelude::*;
   use crate::test_scheduler::ManualScheduler;
-  use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::{Arc, Mutex},
-    time::Duration,
-  };
+  #[cfg(not(target_arch = "wasm32"))]
+  use std::sync::{Arc, Mutex};
+  use std::{cell::RefCell, rc::Rc, time::Duration};
 
   #[test]
   fn sample_base() {

--- a/src/ops/sample.rs
+++ b/src/ops/sample.rs
@@ -163,6 +163,8 @@ mod test {
       assert_eq!(x.borrow().len(), 10);
     };
   }
+
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn sample_by_subject() {
     let mut subject = SharedSubject::new();

--- a/src/ops/scan.rs
+++ b/src/ops/scan.rs
@@ -146,6 +146,7 @@ mod test {
     assert_eq!(vec!(1, 2, 3, 4, 5), emitted);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn scan_fork_and_shared_mixed_types() {
     // type to type can fork
@@ -156,6 +157,7 @@ mod test {
       .subscribe(|_| {});
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn scan_fork_and_shared() {
     // type to type can fork

--- a/src/ops/skip.rs
+++ b/src/ops/skip.rs
@@ -106,6 +106,7 @@ mod test {
     assert_eq!(nc2, 90);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/skip_last.rs
+++ b/src/ops/skip_last.rs
@@ -98,6 +98,7 @@ mod test {
     assert_eq!(nc2, 90);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/skip_while.rs
+++ b/src/ops/skip_while.rs
@@ -105,6 +105,7 @@ mod test {
     assert_eq!(nc2, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/subscribe_on.rs
+++ b/src/ops/subscribe_on.rs
@@ -40,6 +40,7 @@ mod test {
   use std::thread;
   use std::time::Duration;
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn thread_pool() {
     let pool = ThreadPool::new().unwrap();
@@ -61,6 +62,7 @@ mod test {
     assert_ne!(c_thread.lock().unwrap()[0], thread::current().id());
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn pool_unsubscribe() {
     let pool = ThreadPool::new().unwrap();

--- a/src/ops/subscribe_on.rs
+++ b/src/ops/subscribe_on.rs
@@ -32,6 +32,7 @@ impl_local_shared_both! {
     SD: @ctx::Scheduler
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(test)]
 mod test {
   use crate::prelude::*;
@@ -40,7 +41,6 @@ mod test {
   use std::thread;
   use std::time::Duration;
 
-  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn thread_pool() {
     let pool = ThreadPool::new().unwrap();
@@ -62,7 +62,6 @@ mod test {
     assert_ne!(c_thread.lock().unwrap()[0], thread::current().id());
   }
 
-  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn pool_unsubscribe() {
     let pool = ThreadPool::new().unwrap();

--- a/src/ops/take.rs
+++ b/src/ops/take.rs
@@ -96,6 +96,7 @@ mod test {
     assert_eq!(nc2, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/take_last.rs
+++ b/src/ops/take_last.rs
@@ -89,6 +89,7 @@ mod test {
     assert_eq!(nc2, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)

--- a/src/ops/take_until.rs
+++ b/src/ops/take_until.rs
@@ -74,9 +74,9 @@ where
 
 #[cfg(test)]
 mod test {
-  use std::sync::{Arc, Mutex};
-
   use crate::prelude::*;
+  #[cfg(not(target_arch = "wasm32"))]
+  use std::sync::{Arc, Mutex};
 
   #[test]
   fn base_function() {

--- a/src/ops/take_until.rs
+++ b/src/ops/take_until.rs
@@ -109,6 +109,7 @@ mod test {
     assert_eq!(completed_count, 1);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn ininto_shared() {
     let last_next_arg = Arc::new(Mutex::new(None));

--- a/src/ops/take_while.rs
+++ b/src/ops/take_while.rs
@@ -117,6 +117,7 @@ mod test {
     assert_eq!(nc2, 5);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn into_shared() {
     observable::from_iter(0..100)

--- a/src/ops/tap.rs
+++ b/src/ops/tap.rs
@@ -72,6 +72,7 @@ mod test {
     assert_eq!(v, 100);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     // type to type can fork

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -118,7 +118,7 @@ macro_rules! impl_observer {
 }
 
 impl_observer!(MutRc, LocalScheduler);
-#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
+#[cfg(not(all(target_arch = "wasm32")))]
 impl_observer!(MutArc, SharedScheduler, Send);
 
 #[cfg(test)]
@@ -157,6 +157,7 @@ mod tests {
     assert_eq!(&*x_c.rc_deref(), &[0, 3]);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn fork_and_shared() {
     use futures::executor::ThreadPool;

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -118,7 +118,7 @@ macro_rules! impl_observer {
 }
 
 impl_observer!(MutRc, LocalScheduler);
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 impl_observer!(MutArc, SharedScheduler, Send);
 
 #[cfg(test)]

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -118,6 +118,7 @@ macro_rules! impl_observer {
 }
 
 impl_observer!(MutRc, LocalScheduler);
+#[cfg(not(feature = "wasm-scheduler"))]
 impl_observer!(MutArc, SharedScheduler, Send);
 
 #[cfg(test)]

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -82,9 +82,7 @@ impl<T, Item, Err> BufferedMutArc<T, Item, Err> {
 
 impl<T> RcDeref for MutRc<T> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Ref<'a, T>;
+  = Ref<'a, T> where Self: 'a;
   #[inline]
   #[allow(clippy::needless_lifetimes)]
   fn rc_deref<'a>(&'a self) -> Self::Target<'a> { self.0.borrow() }
@@ -92,9 +90,7 @@ impl<T> RcDeref for MutRc<T> {
 
 impl<T> TryRcDeref for MutRc<T> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Result<Ref<'a, T>, BorrowError>;
+  = Result<Ref<'a, T>, BorrowError> where Self: 'a;
   #[inline]
   #[allow(clippy::needless_lifetimes)]
   fn try_rc_deref<'a>(&'a self) -> Self::Target<'a> { self.0.try_borrow() }
@@ -102,9 +98,7 @@ impl<T> TryRcDeref for MutRc<T> {
 
 impl<T> RcDeref for MutArc<T> {
   type Target<'a>
-  where
-    Self: 'a,
-  = MutexGuard<'a, T>;
+  = MutexGuard<'a, T> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -113,9 +107,7 @@ impl<T> RcDeref for MutArc<T> {
 
 impl<T> TryRcDeref for MutArc<T> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>>;
+  = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -124,9 +116,7 @@ impl<T> TryRcDeref for MutArc<T> {
 
 impl<T, Item, Err> RcDeref for BufferedMutRc<T, Item, Err> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Ref<'a, T>;
+  = Ref<'a, T> where Self: 'a;
   #[inline]
   #[allow(clippy::needless_lifetimes)]
   fn rc_deref<'a>(&'a self) -> Self::Target<'a> { self.inner.rc_deref() }
@@ -134,9 +124,7 @@ impl<T, Item, Err> RcDeref for BufferedMutRc<T, Item, Err> {
 
 impl<T, Item, Err> TryRcDeref for BufferedMutRc<T, Item, Err> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Result<Ref<'a, T>, BorrowError>;
+  = Result<Ref<'a, T>, BorrowError> where Self: 'a;
   #[inline]
   #[allow(clippy::needless_lifetimes)]
   fn try_rc_deref<'a>(&'a self) -> Self::Target<'a> {
@@ -146,9 +134,7 @@ impl<T, Item, Err> TryRcDeref for BufferedMutRc<T, Item, Err> {
 
 impl<T, Item, Err> RcDeref for BufferedMutArc<T, Item, Err> {
   type Target<'a>
-  where
-    Self: 'a,
-  = MutexGuard<'a, T>;
+  = MutexGuard<'a, T> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -158,8 +144,7 @@ impl<T, Item, Err> RcDeref for BufferedMutArc<T, Item, Err> {
 impl<T, Item, Err> TryRcDeref for BufferedMutArc<T, Item, Err> {
   type Target<'a>
   where
-    Self: 'a,
-  = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>>;
+  = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -169,10 +154,7 @@ impl<T, Item, Err> TryRcDeref for BufferedMutArc<T, Item, Err> {
 }
 
 impl<T> RcDerefMut for MutRc<T> {
-  type Target<'a>
-  where
-    Self: 'a,
-  = RefMut<'a, T>;
+  type Target<'a> = RefMut<'a, T> where T: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -181,9 +163,7 @@ impl<T> RcDerefMut for MutRc<T> {
 
 impl<T> RcDerefMut for MutArc<T> {
   type Target<'a>
-  where
-    Self: 'a,
-  = MutexGuard<'a, T>;
+  = MutexGuard<'a, T> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -192,9 +172,7 @@ impl<T> RcDerefMut for MutArc<T> {
 
 impl<T, Item, Err> RcDerefMut for BufferedMutRc<T, Item, Err> {
   type Target<'a>
-  where
-    Self: 'a,
-  = RefMut<'a, T>;
+  = RefMut<'a, T> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -205,9 +183,7 @@ impl<T, Item, Err> RcDerefMut for BufferedMutRc<T, Item, Err> {
 
 impl<T, Item, Err> RcDerefMut for BufferedMutArc<T, Item, Err> {
   type Target<'a>
-  where
-    Self: 'a,
-  = MutexGuard<'a, T>;
+  = MutexGuard<'a, T> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -218,9 +194,7 @@ impl<T, Item, Err> RcDerefMut for BufferedMutArc<T, Item, Err> {
 
 impl<T> TryRcDerefMut for MutRc<T> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Result<RefMut<'a, T>, BorrowMutError>;
+  = Result<RefMut<'a, T>, BorrowMutError> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -231,9 +205,7 @@ impl<T> TryRcDerefMut for MutRc<T> {
 
 impl<T> TryRcDerefMut for MutArc<T> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>>;
+  = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -242,9 +214,7 @@ impl<T> TryRcDerefMut for MutArc<T> {
 
 impl<T, Item, Err> TryRcDerefMut for BufferedMutRc<T, Item, Err> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Result<RefMut<'a, T>, BorrowMutError>;
+  = Result<RefMut<'a, T>, BorrowMutError> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]
@@ -255,9 +225,7 @@ impl<T, Item, Err> TryRcDerefMut for BufferedMutRc<T, Item, Err> {
 
 impl<T, Item, Err> TryRcDerefMut for BufferedMutArc<T, Item, Err> {
   type Target<'a>
-  where
-    Self: 'a,
-  = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>>;
+  = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>> where Self: 'a;
 
   #[inline]
   #[allow(clippy::needless_lifetimes)]

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -143,7 +143,6 @@ impl<T, Item, Err> RcDeref for BufferedMutArc<T, Item, Err> {
 
 impl<T, Item, Err> TryRcDeref for BufferedMutArc<T, Item, Err> {
   type Target<'a>
-  where
   = Result<MutexGuard<'a, T>, TryLockError<MutexGuard<'a, T>>> where Self: 'a;
 
   #[inline]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -104,6 +104,7 @@ impl SubscriptionLike for SpawnHandle {
   fn is_closed(&self) -> bool { *self.is_closed.read().unwrap() }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(feature = "futures-scheduler")]
 mod futures_scheduler {
   use crate::scheduler::{LocalScheduler, SharedScheduler};

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -313,3 +313,16 @@ mod wasm_scheduler {
     }
   }
 }
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod test {
+  use crate::prelude::*;
+  use wasm_bindgen_test::*;
+
+  #[wasm_bindgen_test]
+  fn test_local() {
+    let mut container = Vec::new();
+    observable::from_iter(1..=5).subscribe(|val| container.push(val));
+    assert_eq!(container, vec![1, 2, 3, 4, 5]);
+  }
+}

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -300,8 +300,8 @@ mod wasm_scheduler {
 
   impl LocalScheduler for LocalSpawner {
     fn spawn<Fut>(&self, future: Fut)
-      where
-          Fut: Future<Output = ()> + 'static,
+    where
+      Fut: Future<Output = ()> + 'static,
     {
       wasm_bindgen_futures::spawn_local(future.map(|_| ()));
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -17,7 +17,7 @@ pub fn task_future<T>(
   (fut.map(|_| ()), SpawnHandle::new(handle))
 }
 
-#[cfg(not(feature = "wasm-scheduler"))]
+#[cfg(not(all(target_arch = "wasm32", feature = "wasm-scheduler")))]
 /// A Scheduler is an object to order task and schedule their execution.
 pub trait SharedScheduler {
   fn spawn<Fut>(&self, future: Fut)
@@ -293,7 +293,7 @@ mod test {
   }
 }
 
-#[cfg(feature = "wasm-scheduler")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm-scheduler"))]
 mod wasm_scheduler {
   use crate::scheduler::LocalScheduler;
   use futures::{executor::LocalSpawner, Future, FutureExt};

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -283,7 +283,9 @@ where
 #[cfg(test)]
 mod test {
   use super::*;
+  #[cfg(not(target_arch = "wasm32"))]
   use futures::executor::ThreadPool;
+  #[cfg(not(target_arch = "wasm32"))]
   use std::time::{Duration, Instant};
 
   #[test]

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -335,6 +335,7 @@ mod test {
     assert_eq!(i, 0);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn empty_local_subject_can_convert_into_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/subject/behavior_subject.rs
+++ b/src/subject/behavior_subject.rs
@@ -168,6 +168,7 @@ mod test {
     assert_eq!(i, 42);
   }
 
+  #[cfg(not(target_arch = "wasm32"))]
   #[test]
   fn empty_local_subject_can_convert_into_shared() {
     let pool = ThreadPool::new().unwrap();

--- a/src/subject/behavior_subject.rs
+++ b/src/subject/behavior_subject.rs
@@ -114,7 +114,9 @@ impl<'a, Item: Clone, Err> LocalObservable<'a>
 #[cfg(test)]
 mod test {
   use crate::prelude::*;
+  #[cfg(not(target_arch = "wasm32"))]
   use futures::executor::ThreadPool;
+  #[cfg(not(target_arch = "wasm32"))]
   use std::time::{Duration, Instant};
 
   #[test]


### PR DESCRIPTION
This revision includes:
- Support `wasm` build (Resolves #118, #176 and #177)
  - Add new feature 'wasm-scheduler'
  - I removed `SharedScheduler` when `feature` is `wasm-scheduler` and `target_arch` is `wasm32`
  - I tested it with simple example (https://github.com/utilForever/rxrust-with-wasm)