### PR TITLE
fix: don't re-export Instant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ pub mod prelude {
   pub use crate::subscription;
   pub use crate::subscription::*;
   pub use crate::type_hint::TypeHint;
-  pub use fluvio_wasm_timer::Instant;
   pub use observer::Observer;
   pub use shared::*;
 }

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -1,6 +1,6 @@
 use crate::{impl_helper::*, impl_local_shared_both, prelude::*};
 
-use crate::prelude::Instant;
+use fluvio_wasm_timer::Instant;
 use std::time::Duration;
 
 /// Creates an observable which will fire at `dur` time into the future,

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -1,6 +1,7 @@
-use crate::{impl_helper::*, impl_local_shared_both, prelude::*};
+use crate::{
+  impl_helper::*, impl_local_shared_both, prelude::*, scheduler::Instant,
+};
 
-use fluvio_wasm_timer::Instant;
 use std::time::Duration;
 
 /// Creates an observable which will fire at `dur` time into the future,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,12 +1,13 @@
 use crate::prelude::*;
 use async_std::prelude::FutureExt as AsyncFutureExt;
-use fluvio_wasm_timer::Instant;
 use futures::future::{lazy, AbortHandle, FutureExt};
 use std::future::Future;
 
 use futures::StreamExt;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+
+pub(crate) use fluvio_wasm_timer::Instant;
 
 pub fn task_future<T>(
   task: impl FnOnce(T) + 'static,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use async_std::prelude::FutureExt as AsyncFutureExt;
+use fluvio_wasm_timer::Instant;
 use futures::future::{lazy, AbortHandle, FutureExt};
 use std::future::Future;
 

--- a/src/test_scheduler.rs
+++ b/src/test_scheduler.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
-use crate::prelude::{Instant, LocalScheduler, SpawnHandle, SubscriptionLike};
+use crate::prelude::{LocalScheduler, SpawnHandle, SubscriptionLike};
+use fluvio_wasm_timer::Instant;
 use futures::future::AbortHandle;
 use std::future::Future;
 use std::ops::{Add, Sub};

--- a/src/test_scheduler.rs
+++ b/src/test_scheduler.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use crate::prelude::{LocalScheduler, SpawnHandle, SubscriptionLike};
-use fluvio_wasm_timer::Instant;
+use crate::scheduler::Instant;
 use futures::future::AbortHandle;
 use std::future::Future;
 use std::ops::{Add, Sub};


### PR DESCRIPTION
In the previous PR(#189), I included Instant type in the prelude. 
But now I think this is bad idea, because if the use of rxRust does following,

```rust
use rxrust::prelude::*;
use std::time::Instant;
```

it will cause name collision. And I think this can happen quite often.