### PR TITLE
fix: revise the interface of Instant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,9 @@ pub mod prelude {
   pub use crate::rc::*;
   #[cfg(target_arch = "wasm32")]
   pub use crate::scheduler::LocalSpawner;
-  pub use crate::scheduler::{task_future, LocalScheduler, SpawnHandle};
   #[cfg(not(target_arch = "wasm32"))]
   pub use crate::scheduler::SharedScheduler;
+  pub use crate::scheduler::{task_future, LocalScheduler, SpawnHandle};
   pub use crate::shared;
   pub use crate::subject;
   pub use crate::subject::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,11 @@ pub mod prelude {
   pub use crate::observer;
   pub use crate::ops;
   pub use crate::rc::*;
-  pub use crate::scheduler::*;
+  #[cfg(target_arch = "wasm32")]
+  pub use crate::scheduler::LocalSpawner;
+  pub use crate::scheduler::{task_future, LocalScheduler, SpawnHandle};
+  #[cfg(not(target_arch = "wasm32"))]
+  pub use crate::scheduler::SharedScheduler;
   pub use crate::shared;
   pub use crate::subject;
   pub use crate::subject::*;

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -51,6 +51,7 @@ use crate::ops::default_if_empty::DefaultIfEmptyOp;
 use crate::ops::distinct::{DistinctKeyOp, DistinctUntilKeyChangedOp};
 use crate::ops::pairwise::PairwiseOp;
 use crate::ops::tap::TapOp;
+use crate::scheduler::Instant;
 use ops::{
   box_it::{BoxOp, IntoBox},
   buffer::{BufferWithCountOp, BufferWithCountOrTimerOp, BufferWithTimeOp},
@@ -89,7 +90,7 @@ use ops::{
   Accum, AverageOp, CountOp, FlatMapOp, MinMaxOp, ReduceOp, SumOp,
 };
 use std::ops::{Add, Mul};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 type ALLOp<O, F> =
   DefaultIfEmptyOp<TakeOp<FilterOp<MapOp<O, F>, fn(&bool) -> bool>>>;

--- a/src/observable/observable_block.rs
+++ b/src/observable/observable_block.rs
@@ -90,9 +90,10 @@ where
 #[cfg(test)]
 mod test {
   use crate::prelude::*;
+  use crate::scheduler::Instant;
   use futures::executor::ThreadPool;
   use std::sync::{Arc, Mutex};
-  use std::time::{Duration, Instant};
+  use std::time::Duration;
 
   #[test]
   fn blocks_shared() {

--- a/src/observable/observable_block_all.rs
+++ b/src/observable/observable_block_all.rs
@@ -115,9 +115,10 @@ where
 #[cfg(test)]
 mod test {
   use crate::prelude::*;
+  use crate::scheduler::Instant;
   use futures::executor::ThreadPool;
   use std::sync::{Arc, Mutex};
-  use std::time::{Duration, Instant};
+  use std::time::Duration;
 
   #[test]
   fn blocks_shared() {

--- a/src/observable/timer.rs
+++ b/src/observable/timer.rs
@@ -1,5 +1,7 @@
-use crate::{impl_helper::*, impl_local_shared_both, prelude::*};
-use std::time::{Duration, Instant};
+use crate::{
+  impl_helper::*, impl_local_shared_both, prelude::*, scheduler::Instant,
+};
+use std::time::Duration;
 
 // Returns an observable which will emit a single `item`
 // once after a given `dur` using a given `scheduler`
@@ -79,12 +81,13 @@ impl_local_shared_both! {
 #[cfg(test)]
 mod tests {
   use crate::prelude::*;
+  use crate::scheduler::Instant;
   use futures::executor::LocalPool;
   #[cfg(not(target_arch = "wasm32"))]
   use futures::executor::ThreadPool;
   use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
   use std::sync::Arc;
-  use std::time::{Duration, Instant};
+  use std::time::Duration;
 
   #[test]
   fn timer_shall_emit_value() {

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
-use crate::{impl_helper::*, impl_local_shared_both};
 use crate::scheduler::Instant;
+use crate::{impl_helper::*, impl_local_shared_both};
 use std::time::Duration;
 #[derive(Clone)]
 pub struct DebounceOp<S, SD> {

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::{impl_helper::*, impl_local_shared_both};
-use std::time::{Duration, Instant};
+use crate::scheduler::Instant;
+use std::time::Duration;
 #[derive(Clone)]
 pub struct DebounceOp<S, SD> {
   pub(crate) source: S,

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -39,12 +39,12 @@ impl_local_shared_both! {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::scheduler::Instant;
   use futures::executor::LocalPool;
   #[cfg(not(target_arch = "wasm32"))]
   use futures::executor::ThreadPool;
   #[cfg(not(target_arch = "wasm32"))]
   use std::sync::{Arc, Mutex};
-  use std::time::Instant;
   use std::{cell::RefCell, rc::Rc};
 
   #[cfg(not(target_arch = "wasm32"))]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -7,7 +7,7 @@ use futures::StreamExt;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-pub(crate) use fluvio_wasm_timer::Instant;
+pub use fluvio_wasm_timer::Instant;
 
 pub fn task_future<T>(
   task: impl FnOnce(T) + 'static,
@@ -174,7 +174,7 @@ fn to_interval(
     .delay(delay)
 }
 
-#[cfg(feature = "tokio-scheduler")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "tokio-scheduler"))]
 mod tokio_scheduler {
   use super::*;
   use std::sync::Arc;
@@ -199,7 +199,7 @@ mod tokio_scheduler {
   }
 }
 
-#[cfg(all(test, feature = "tokio-scheduler"))]
+#[cfg(all(test, not(target_arch = "wasm32"), feature = "tokio-scheduler"))]
 mod test {
   use crate::prelude::*;
   use bencher::Bencher;

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -284,9 +284,11 @@ where
 mod test {
   use super::*;
   #[cfg(not(target_arch = "wasm32"))]
+  use crate::scheduler::Instant;
+  #[cfg(not(target_arch = "wasm32"))]
   use futures::executor::ThreadPool;
   #[cfg(not(target_arch = "wasm32"))]
-  use std::time::{Duration, Instant};
+  use std::time::Duration;
 
   #[test]
   fn smoke() {

--- a/src/subject/behavior_subject.rs
+++ b/src/subject/behavior_subject.rs
@@ -115,9 +115,11 @@ impl<'a, Item: Clone, Err> LocalObservable<'a>
 mod test {
   use crate::prelude::*;
   #[cfg(not(target_arch = "wasm32"))]
+  use crate::scheduler::Instant;
+  #[cfg(not(target_arch = "wasm32"))]
   use futures::executor::ThreadPool;
   #[cfg(not(target_arch = "wasm32"))]
-  use std::time::{Duration, Instant};
+  use std::time::Duration;
 
   #[test]
   fn base_data_flow() {


### PR DESCRIPTION
Problem in #190 is that it requires me to add fluvio-wasm-timer separately in the cargo.
Say, if you make timer observable, you will provide value of `Instant` as a argument, 
so you need to add the dependency of fluvio-wasm-timer to make target-indenpendant `Instant`.

I think I misunderstood what @M-Adoo in the previous PR, so here is a little modification.
We will export `fluvio_wasm_timer::Instant` through `rxrust::scheduler::Instant`, but not as `rxrust::prelude::Instant`.

Additionally I updated internal use of `Instant`s from `std::time::Instant` to `crate::scheduler::Instant`.