### PR TITLE
Fix problem that operator 'interval()' is delayed in WebAssembly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,15 @@ optional = true
 version = "0.4.29"
 optional = true
 
+[dependencies.gloo-timers]
+version = "0.2.4"
+optional = true
+
 [features]
 default = ["futures-scheduler"]
 tokio-scheduler = ["tokio"]
 futures-scheduler = []
-wasm-scheduler = ["wasm-bindgen-futures"]
+wasm-scheduler = ["wasm-bindgen-futures", "gloo-timers"]
 
 [dev-dependencies]
 float-cmp = "0.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! [Observable](crate::observable::Observable), to make
 //! it easier to compose asynchronous or callback-based code.
 #![recursion_limit = "256"]
-#![feature(generic_associated_types)]
 #![doc = include_str!("../README.md")]
 
 #[cfg(test)]

--- a/src/ops/tap.rs
+++ b/src/ops/tap.rs
@@ -77,19 +77,19 @@ mod test {
   fn fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(0..100).map(|v| v);
-    m.tap(|v| println!("v: {}", v))
+    m.tap(|v| println!("v: {v}"))
       .into_shared()
       .subscribe(|_| {});
 
     // type mapped to other type can fork
     let m = observable::from_iter(vec!['a', 'b', 'c']).map(|_v| 1);
-    m.tap(|v| println!("v: {}", v))
+    m.tap(|v| println!("v: {v}"))
       .into_shared()
       .subscribe(|_| {});
 
     // ref to ref can fork
     let m = observable::of(&1).map(|v| v);
-    m.tap(|v| println!("v: {}", v))
+    m.tap(|v| println!("v: {v}"))
       .into_shared()
       .subscribe(|_| {});
   }


### PR DESCRIPTION
This revision includes:
- Fix problem that operator 'interval()' is delayed in WebAssembly
  - Add crate 'gloo-timers'
  - Replace code 'fluvio_wasm_timer::Interval' with 'IntervalStream'