### PR TITLE
implement std::ops::Deref for BehaviorSubject

### DIFF
--- a/src/subject/behavior_subject.rs
+++ b/src/subject/behavior_subject.rs
@@ -121,6 +121,14 @@ impl<'a, Item: Clone, Err> LocalObservable<'a>
   }
 }
 
+impl<'a, Item, Err> std::ops::Deref for BehaviorSubject<Item, Err> {
+  type Target = Item;
+
+  fn deref(&self) -> &Self::Target {
+    &self.value
+  }
+}
+
 #[cfg(test)]
 mod test {
   use crate::prelude::*;


### PR DESCRIPTION
### Rationale
By implementing `std::ops::Deref` for `BehaviorSubject`, the user can peek the current value contained in it:
- Idiomatically
- safely (no mutation without using `next`, since it returns an immutable ref)
- simply

### Example use
```rust
let subject = LocalBehaviorSubject::new(0);

// --snip--

button.connect_clicked(move || subject.next(subject + 1))
```

resolves rxRust/rxRust#212