### PR TITLE
Fix the logic of operator 'skip_while()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bug Fixes
 - **operator**: `distinct_until_changed` only require the value implement `PartialEq` not `Eq`.
-- **operator**: `group_by` should not subscribe to value source anew on each new group 
+- **operator**: `group_by` should not subscribe to value source anew on each new group.
+- **operator**: Fix the logic of operator `skip_while`.
 
 ## [1.0.0-alpha.4](https://github.com/rxRust/rxRust/releases/tag/v1.0.0-alpha.4)
 ### Features

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -547,7 +547,7 @@ pub trait Observable: Sized {
     }
   }
 
-  /// Ignore values while result of a callback is true.
+  /// Discard items emitted by an Observable until a specified condition becomes false.
   ///
   /// `skip_while` returns an Observable that ignores values while result of an
   /// callback is true emitted by the source Observable.
@@ -559,7 +559,7 @@ pub trait Observable: Sized {
   /// # use rxrust::prelude::*;
   ///
   /// observable::from_iter(0..10)
-  ///   .skip_while(|v| v < &5)
+  ///   .skip_while(|v| v != &5)
   ///   .subscribe(|v| println!("{}", v));
   ///
   /// // print logs:
@@ -570,13 +570,13 @@ pub trait Observable: Sized {
   /// // 9
   /// ```
   #[inline]
-  fn skip_while<F>(self, callback: F) -> SkipWhileOp<Self, F>
+  fn skip_while<F>(self, predicate: F) -> SkipWhileOp<Self, F>
   where
     F: FnMut(&Self::Item) -> bool,
   {
     SkipWhileOp {
       source: self,
-      callback,
+      predicate,
     }
   }
 

--- a/src/ops/skip_while.rs
+++ b/src/ops/skip_while.rs
@@ -77,7 +77,7 @@ mod test {
     let mut next_count = 0;
 
     observable::from_iter(0..100)
-      .skip_while(|v| v < &95)
+      .skip_while(|v| v != &95)
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
     assert_eq!(next_count, 5);
@@ -89,12 +89,12 @@ mod test {
     let mut nc1 = 0;
     let mut nc2 = 0;
     {
-      let skip_while5 = observable::from_iter(0..100).skip_while(|v| v < &95);
+      let skip_while5 = observable::from_iter(0..100).skip_while(|v| v != &95);
       let f1 = skip_while5.clone();
       let f2 = skip_while5;
 
-      f1.skip_while(|v| v < &95).subscribe(|_| nc1 += 1);
-      f2.skip_while(|v| v < &95).subscribe(|_| nc2 += 1);
+      f1.skip_while(|v| v != &95).subscribe(|_| nc1 += 1);
+      f2.skip_while(|v| v != &95).subscribe(|_| nc2 += 1);
     }
     assert_eq!(nc1, 5);
     assert_eq!(nc2, 5);
@@ -104,8 +104,8 @@ mod test {
   #[test]
   fn ininto_shared() {
     observable::from_iter(0..100)
-      .skip_while(|v| v < &95)
-      .skip_while(|v| v < &95)
+      .skip_while(|v| v != &95)
+      .skip_while(|v| v != &95)
       .into_shared()
       .subscribe(|_| {});
   }


### PR DESCRIPTION
This revision includes:
- Fix the logic of operator 'skip_while()'
  - `SkipWhile` discard items emitted by an Observable until a specified condition becomes false.
- Fix unit test code of operator 'skip_while()'
- Separate unit test code of `Timer` according to wasm build
- Reference: https://reactivex.io/documentation/operators/skipwhile.html