### PR TITLE
Fix `delay` op  not really delay emission and  related bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This is a big refactor for rxRust, almost reimplement everything and many api wa
 - **operator**: `distinct_until_changed` only require the value implement `PartialEq` not `Eq`.
 - **operator**: `group_by` should not subscribe to value source anew on each new group
 - **operator**: `delay` operator not really delay the emission but on delay the init subscription.
+- **scheduler**: unsubscribe the handle of parallels scheduler not always cancel the remote task.
 ## [1.0.0-alpha.4](https://github.com/rxRust/rxRust/releases/tag/v1.0.0-alpha.4)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,14 @@ This is a big refactor for rxRust, almost reimplement everything and many api wa
 - **operator**: add `complete_status` operator to track the complete status of the observable, and can use to block the thread until the observable finished.
 - **operator**: add `to_future` operator to convert an observable into a `Future`.
 - **operator**: add `to_stream` operator to convert an observable into a `Stream`.
+- **operator**: add `delay_subscription` to only delay the initial subscription.
 - **test**: reimplement the `FakeTimer` help us to control the timer when we write unit test.
 
 ### Bug Fixes
 
 - **operator**: `distinct_until_changed` only require the value implement `PartialEq` not `Eq`.
 - **operator**: `group_by` should not subscribe to value source anew on each new group
-
+- **operator**: `delay` operator not really delay the emission but on delay the init subscription.
 ## [1.0.0-alpha.4](https://github.com/rxRust/rxRust/releases/tag/v1.0.0-alpha.4)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ let threads_scheduler = FuturesThreadPoolScheduler::new().unwrap();
 observable::from_iter(0..10)
   .subscribe_on(threads_scheduler.clone())
   .map(|v| v*2)
-  .observe_on(threads_scheduler)
+  .observe_on_threads(threads_scheduler)
   .subscribe(|v| println!("{},", v));
 ```
 

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -39,6 +39,7 @@ use crate::ops::finalize::FinalizeOpThreads;
 use crate::ops::future::{ObservableFuture, ObservableFutureObserver};
 use crate::ops::merge::MergeOpThreads;
 use crate::ops::merge_all::MergeAllOpThreads;
+use crate::ops::observe_on::ObserveOnOpThreads;
 use crate::ops::on_complete::OnCompleteOp;
 use crate::ops::ref_count::{ShareOp, ShareOpThreads};
 use crate::ops::sample::SampleOpThreads;
@@ -1271,6 +1272,15 @@ pub trait ObservableExt<Item, Err>: Sized {
   #[inline]
   fn observe_on<SD>(self, scheduler: SD) -> ObserveOnOp<Self, SD> {
     ObserveOnOp { source: self, scheduler }
+  }
+
+  /// A thread safe version of `observe_on`
+  #[inline]
+  fn observe_on_threads<SD>(
+    self,
+    scheduler: SD,
+  ) -> ObserveOnOpThreads<Self, SD> {
+    ObserveOnOpThreads { source: self, scheduler }
   }
 
   /// Emits a value from the source Observable only after a particular time span

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -34,6 +34,7 @@ pub use defer::*;
 
 use crate::ops::combine_latest::CombineLatestOpThread;
 use crate::ops::complete_status::{CompleteStatus, StatusOp};
+use crate::ops::delay::{DelayOpThreads, DelaySubscriptionOp};
 use crate::ops::finalize::FinalizeOpThreads;
 use crate::ops::future::{ObservableFuture, ObservableFutureObserver};
 use crate::ops::merge::MergeOpThreads;
@@ -1156,9 +1157,58 @@ pub trait ObservableExt<Item, Err>: Sized {
     DelayOp { source: self, delay: dur, scheduler }
   }
 
+  /// A threads safe version of `delay`
+  #[inline]
+  fn delay_threads<SD>(
+    self,
+    dur: Duration,
+    scheduler: SD,
+  ) -> DelayOpThreads<Self, SD> {
+    DelayOpThreads { source: self, delay: dur, scheduler }
+  }
+
   #[inline]
   fn delay_at<SD>(self, at: Instant, scheduler: SD) -> DelayOp<Self, SD> {
     DelayOp {
+      source: self,
+      delay: at.elapsed(),
+      scheduler,
+    }
+  }
+
+  /// A threads safe version of `delay_at`
+  #[inline]
+  fn delay_at_threads<SD>(
+    self,
+    at: Instant,
+    scheduler: SD,
+  ) -> DelayOpThreads<Self, SD> {
+    DelayOpThreads {
+      source: self,
+      delay: at.elapsed(),
+      scheduler,
+    }
+  }
+
+  /// It's similar to delay but rather than timeshifting the emissions from
+  /// the source Observable, it timeshifts the moment of subscription to that
+  /// Observable.
+  #[inline]
+  fn delay_subscription<SD>(
+    self,
+    dur: Duration,
+    scheduler: SD,
+  ) -> DelaySubscriptionOp<Self, SD> {
+    DelaySubscriptionOp { source: self, delay: dur, scheduler }
+  }
+
+  #[inline]
+  fn delay_subscription_at<SD>(
+    self,
+    at: Instant,
+    scheduler: SD,
+  ) -> DelaySubscriptionOp<Self, SD> {
+    DelaySubscriptionOp {
       source: self,
       delay: at.elapsed(),
       scheduler,

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -1,14 +1,46 @@
-use crate::prelude::*;
+use crate::{
+  prelude::*,
+  rc::{MutArc, MutRc},
+};
 use std::time::Duration;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DelayOp<S, SD> {
   pub(crate) source: S,
   pub(crate) delay: Duration,
   pub(crate) scheduler: SD,
 }
 
-impl<Item, Err, O, S, SD> Observable<Item, Err, O> for DelayOp<S, SD>
+#[derive(Debug, Clone)]
+pub struct DelayOpThreads<S, SD> {
+  pub(crate) source: S,
+  pub(crate) delay: Duration,
+  pub(crate) scheduler: SD,
+}
+
+#[derive(Debug, Clone)]
+pub struct DelaySubscriptionOp<S, SD> {
+  pub(crate) source: S,
+  pub(crate) delay: Duration,
+  pub(crate) scheduler: SD,
+}
+
+pub struct DelayObserver<O, SD> {
+  delay: Duration,
+  scheduler: SD,
+  observer: MutRc<Option<O>>,
+  subscription: MultiSubscription<'static>,
+}
+
+pub struct DelayObserverThreads<O, SD> {
+  delay: Duration,
+  scheduler: SD,
+  observer: MutArc<Option<O>>,
+  subscription: MultiSubscriptionThreads,
+}
+
+impl<Item, Err, O, S, SD> Observable<Item, Err, O>
+  for DelaySubscriptionOp<S, SD>
 where
   O: Observer<Item, Err>,
   S: Observable<Item, Err, O>,
@@ -23,12 +55,97 @@ where
   }
 }
 
-impl<Item, Err, S, SD> ObservableExt<Item, Err> for DelayOp<S, SD> where
+macro_rules! impl_delay_op {
+  ($op: ty, $rc: ident, $observer: ident, $multi_unsub: ty, $box_unsub: ident) => {
+    impl<Item, Err, O, S, SD> Observable<Item, Err, O> for $op
+    where
+      O: Observer<Item, Err>,
+      S: Observable<Item, Err, $observer<O, SD>>,
+      SD: Scheduler<OnceTask<($rc<Option<O>>, Item), NormalReturn<()>>>,
+      SD: Scheduler<OnceTask<$rc<Option<O>>, NormalReturn<()>>>,
+    {
+      type Unsub = ZipSubscription<S::Unsub, $multi_unsub>;
+
+      fn actual_subscribe(self, observer: O) -> Self::Unsub {
+        let Self { source, delay, scheduler } = self;
+        let subscription: $multi_unsub = <_>::default();
+        let observer = $rc::own(Some(observer));
+        let observer = $observer {
+          delay,
+          scheduler,
+          observer,
+          subscription: subscription.clone(),
+        };
+        let unsub = source.actual_subscribe(observer);
+        ZipSubscription::new(unsub, subscription)
+      }
+    }
+
+    impl<Item, Err, O, SD> Observer<Item, Err> for $observer<O, SD>
+    where
+      O: Observer<Item, Err>,
+      SD: Scheduler<OnceTask<($rc<Option<O>>, Item), NormalReturn<()>>>,
+      SD: Scheduler<OnceTask<$rc<Option<O>>, NormalReturn<()>>>,
+    {
+      fn next(&mut self, value: Item) {
+        fn delay_emit_task<Item, Err>(
+          (mut observer, value): (impl Observer<Item, Err>, Item),
+        ) -> NormalReturn<()> {
+          observer.next(value);
+          NormalReturn::new(())
+        }
+
+        let observer = self.observer.clone();
+        let task = OnceTask::new(delay_emit_task, (observer, value));
+        self.subscription.retain();
+        let handler = self.scheduler.schedule(task, Some(self.delay));
+        self.subscription.append($box_unsub::new(handler));
+      }
+
+      #[inline]
+      fn error(self, err: Err) {
+        self.observer.error(err)
+      }
+
+      #[inline]
+      fn complete(mut self) {
+        fn delay_complete<Item, Err>(
+          observer: impl Observer<Item, Err>,
+        ) -> NormalReturn<()> {
+          observer.complete();
+          NormalReturn::new(())
+        }
+
+        let observer = self.observer.clone();
+        let task = OnceTask::new(delay_complete, observer);
+        self.subscription.retain();
+
+        let handler = self.scheduler.schedule(task, Some(self.delay));
+        self.subscription.append($box_unsub::new(handler));
+      }
+
+      #[inline]
+      fn is_finished(&self) -> bool {
+        self.observer.is_finished()
+      }
+    }
+
+    impl<Item, Err, S, SD> ObservableExt<Item, Err> for $op where
+      S: ObservableExt<Item, Err>
+    {
+    }
+  };
+}
+
+impl_delay_op!(DelayOp<S,SD>, MutRc, DelayObserver, MultiSubscription<'static>, BoxSubscription);
+impl_delay_op!(DelayOpThreads<S,SD>, MutArc, DelayObserverThreads, MultiSubscriptionThreads, BoxSubscriptionThreads);
+
+impl<Item, Err, S, SD> ObservableExt<Item, Err> for DelaySubscriptionOp<S, SD> where
   S: ObservableExt<Item, Err>
 {
 }
 
-pub fn subscribe_task<S, O, Item, Err>(
+fn subscribe_task<S, O, Item, Err>(
   (source, observer): (S, O),
 ) -> SubscribeReturn<S::Unsub>
 where
@@ -40,6 +157,8 @@ where
 
 #[cfg(test)]
 mod tests {
+  use crate::rc::{MutRc, RcDeref, RcDerefMut};
+
   use super::*;
   use futures::executor::LocalPool;
   use std::{cell::RefCell, rc::Rc, time::Instant};
@@ -57,7 +176,7 @@ mod tests {
     let pool = ThreadPool::new().unwrap();
     let stamp = Instant::now();
     let (o, status) = observable::of(1)
-      .delay(Duration::from_millis(50), pool)
+      .delay_threads(Duration::from_millis(1), pool)
       .complete_status();
 
     o.subscribe(move |v| {
@@ -65,7 +184,7 @@ mod tests {
     });
     CompleteStatus::wait_for_end(status);
 
-    assert!(stamp.elapsed() > Duration::from_millis(50));
+    assert!(stamp.elapsed() >= Duration::from_millis(1));
     assert_eq!(*c_value.lock().unwrap(), 1);
   }
 
@@ -75,14 +194,63 @@ mod tests {
     let c_value = value.clone();
     let mut pool = LocalPool::new();
     observable::of(1)
-      .delay(Duration::from_millis(50), pool.spawner())
+      .delay(Duration::from_millis(1), pool.spawner())
       .subscribe(move |v| {
         *c_value.borrow_mut() = v;
       });
     assert_eq!(*value.borrow(), 0);
     let stamp = Instant::now();
     pool.run();
-    assert!(stamp.elapsed() > Duration::from_millis(50));
+    assert!(stamp.elapsed() >= Duration::from_millis(1));
     assert_eq!(*value.borrow(), 1);
+  }
+
+  #[test]
+  fn delay_subscription_smoke() {
+    let accept_stamp = MutRc::own(Instant::now());
+    let c_accept_stamp = accept_stamp.clone();
+
+    let mut pool = LocalPool::new();
+    let mut subject = Subject::default();
+    observable::of(1)
+      .merge(subject.clone())
+      .delay_subscription(Duration::from_millis(1), pool.spawner())
+      .subscribe(move |_| *c_accept_stamp.rc_deref_mut() = Instant::now());
+    pool.run();
+
+    // the subscription delay.
+    assert!(accept_stamp.rc_deref().elapsed() < Duration::from_millis(1));
+    let emit_at = Instant::now();
+    subject.next(0);
+    pool.run();
+    // emit not delay.
+    assert!(accept_stamp.rc_deref().elapsed() < Duration::from_millis(1));
+    assert!(
+      accept_stamp.rc_deref().duration_since(emit_at)
+        < Duration::from_millis(1)
+    );
+  }
+
+  #[test]
+  fn fix_delay_op_should_delay_value_emit() {
+    let accept_stamp = MutRc::own(Instant::now());
+    let c_accept_stamp = accept_stamp.clone();
+    let mut pool = LocalPool::new();
+
+    let mut subject = Subject::default();
+    subject
+      .clone()
+      .delay(Duration::from_millis(1), pool.spawner())
+      .subscribe(move |_| *c_accept_stamp.rc_deref_mut() = Instant::now());
+
+    let emit_at = Instant::now();
+    subject.next(());
+    pool.run();
+
+    assert!(
+      accept_stamp.rc_deref().duration_since(emit_at)
+        >= Duration::from_millis(1)
+    );
+    assert!(accept_stamp.rc_deref().elapsed() < Duration::from_millis(1));
   }
 }

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -88,7 +88,7 @@ macro_rules! impl_delay_op {
       SD: Scheduler<OnceTask<$rc<Option<O>>, NormalReturn<()>>>,
     {
       fn next(&mut self, value: Item) {
-        fn delay_emit_task<Item, Err>(
+        fn delay_emit_value<Item, Err>(
           (mut observer, value): (impl Observer<Item, Err>, Item),
         ) -> NormalReturn<()> {
           observer.next(value);
@@ -96,7 +96,7 @@ macro_rules! impl_delay_op {
         }
 
         let observer = self.observer.clone();
-        let task = OnceTask::new(delay_emit_task, (observer, value));
+        let task = OnceTask::new(delay_emit_value, (observer, value));
         self.subscription.retain();
         let handler = self.scheduler.schedule(task, Some(self.delay));
         self.subscription.append($box_unsub::new(handler));

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -194,8 +194,8 @@ mod test {
     let emitted = Arc::new(Mutex::new(vec![]));
     let c_emitted = emitted.clone();
     observable::from_iter(0..10)
-      .observe_on(scheduler.clone())
-      .delay(Duration::from_millis(10), scheduler)
+      .delay_threads(Duration::from_millis(10), scheduler.clone())
+      .observe_on(scheduler)
       .subscribe(move |v| {
         emitted.lock().unwrap().push(v);
       })

--- a/src/ops/subscribe_on.rs
+++ b/src/ops/subscribe_on.rs
@@ -73,17 +73,18 @@ mod test {
   #[test]
   fn pool_unsubscribe() {
     let pool = ThreadPool::new().unwrap();
-    let emitted = Arc::new(Mutex::new(vec![]));
+    let emitted = Arc::new(Mutex::new(0));
     let c_emitted = emitted.clone();
     observable::from_iter(0..10)
       .delay_threads(Duration::from_millis(10), pool.clone())
       .subscribe_on(pool)
-      .subscribe(move |v| {
-        emitted.lock().unwrap().push(v);
+      .subscribe(move |_| {
+        eprintln!("accept value");
+        *emitted.lock().unwrap() += 1;
       })
       .unsubscribe();
     std::thread::sleep(Duration::from_millis(20));
-    assert_eq!(c_emitted.lock().unwrap().len(), 0);
+    assert_eq!(*c_emitted.lock().unwrap(), 0);
   }
 
   #[test]

--- a/src/ops/subscribe_on.rs
+++ b/src/ops/subscribe_on.rs
@@ -76,8 +76,8 @@ mod test {
     let emitted = Arc::new(Mutex::new(vec![]));
     let c_emitted = emitted.clone();
     observable::from_iter(0..10)
-      .subscribe_on(pool.clone())
-      .delay(Duration::from_millis(10), pool)
+      .delay_threads(Duration::from_millis(10), pool.clone())
+      .subscribe_on(pool)
       .subscribe(move |v| {
         emitted.lock().unwrap().push(v);
       })

--- a/src/ops/throttle.rs
+++ b/src/ops/throttle.rs
@@ -59,7 +59,7 @@ where
       edge,
       duration_selector,
       trailing_value: MutArc::own(None),
-      task_handler: TaskHandle::value(NormalReturn::new(())),
+      task_handler: TaskHandle::value_handle(NormalReturn::new(())),
       scheduler,
     })
   }


### PR DESCRIPTION
 1. fix `delay` operator not really delay the emission but delay subscribe; 
 2. add `delay_subscription` to only delay the initial subscription
 3. fix unsubscribe the handle of parallels scheduler not always cancel the remote task correctly
