### PR TITLE
Changed unit for infallible to represent errors that can never happen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a big refactor for rxRust, almost reimplement everything and many api wa
 - `LocalScheduler` and `SharedScheduler` has been removed, use `Scheduler` instead.
 - `Item` `Err` in `Observer` use generic type instead of associated type.
 - `SubscriptionLike` rename to `Subscription`.
+- removed usage of `()` unit for error that can not happen for `Infallible`
 
 ### Features
 

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -48,6 +48,7 @@ use crate::ops::merge::MergeOpThreads;
 use crate::ops::merge_all::MergeAllOpThreads;
 use crate::ops::observe_on::ObserveOnOpThreads;
 use crate::ops::on_complete::OnCompleteOp;
+use crate::ops::on_error::OnErrorOp;
 use crate::ops::ref_count::{ShareOp, ShareOpThreads};
 use crate::ops::sample::SampleOpThreads;
 use crate::ops::skip_until::SkipUntilOpThreads;
@@ -1666,11 +1667,11 @@ pub trait ObservableExt<Item, Err>: Sized {
   /// Process the error of the observable and the return observable can't catch the error any more.
   #[inline]
   #[must_use]
-  fn on_error<F>(self, f: F) -> OnErrorMapOp<Self, F, Err>
+  fn on_error<F>(self, f: F) -> OnErrorOp<Self, F, Err>
   where
-    F: FnMut(Err),
+    F: FnOnce(Err),
   {
-    OnErrorMapOp::new(self, f)
+    OnErrorOp::new(self, f)
   }
 
   #[inline]

--- a/src/observable/fake_timer.rs
+++ b/src/observable/fake_timer.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use std::{
   collections::VecDeque,
+  convert::Infallible,
   time::{Duration, Instant},
 };
 
@@ -23,11 +24,11 @@ enum TimerObserver {
     at: Instant,
     seq: usize,
     duration: Duration,
-    task: Box<dyn Publisher<usize, ()>>,
+    task: Box<dyn Publisher<usize, Infallible>>,
   },
   Timer {
     at: Instant,
-    task: Box<dyn Publisher<Instant, ()>>,
+    task: Box<dyn Publisher<Instant, Infallible>>,
   },
 }
 
@@ -133,9 +134,9 @@ pub struct DelayObservable {
   timer: FakeClock,
 }
 
-impl<O> Observable<usize, (), O> for IntervalObservable
+impl<O> Observable<usize, Infallible, O> for IntervalObservable
 where
-  O: Observer<usize, ()> + 'static,
+  O: Observer<usize, Infallible> + 'static,
 {
   type Unsub = Subscriber<O>;
 
@@ -152,11 +153,11 @@ where
   }
 }
 
-impl ObservableExt<usize, ()> for IntervalObservable {}
+impl ObservableExt<usize, Infallible> for IntervalObservable {}
 
-impl<O> Observable<Instant, (), O> for DelayObservable
+impl<O> Observable<Instant, Infallible, O> for DelayObservable
 where
-  O: Observer<Instant, ()> + 'static,
+  O: Observer<Instant, Infallible> + 'static,
 {
   type Unsub = Subscriber<O>;
 
@@ -171,4 +172,4 @@ where
   }
 }
 
-impl ObservableExt<Instant, ()> for DelayObservable {}
+impl ObservableExt<Instant, Infallible> for DelayObservable {}

--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -2,7 +2,7 @@ use crate::{
   prelude::*,
   scheduler::{FutureTask, NormalReturn, Scheduler, TaskHandle},
 };
-use std::future::Future;
+use std::{convert::Infallible, future::Future};
 
 /// Converts a `Future` to an observable sequence. Even though if the future
 /// poll value has `Result::Err` type, also emit as a normal value, not trigger
@@ -35,11 +35,11 @@ pub struct FutureObservable<F, S> {
   scheduler: S,
 }
 
-impl<O, F, S> Observable<F::Output, (), O> for FutureObservable<F, S>
+impl<O, F, S> Observable<F::Output, Infallible, O> for FutureObservable<F, S>
 where
   F: Future,
   S: Scheduler<FutureTask<F, O, NormalReturn<()>>>,
-  O: Observer<F::Output, ()>,
+  O: Observer<F::Output, Infallible>,
 {
   type Unsub = TaskHandle<NormalReturn<()>>;
 
@@ -54,7 +54,7 @@ impl<F: Future, S> ObservableExt<F::Output, ()> for FutureObservable<F, S> {}
 
 fn item_task<Item, O>(item: Item, mut observer: O) -> NormalReturn<()>
 where
-  O: Observer<Item, ()>,
+  O: Observer<Item, Infallible>,
 {
   observer.next(item);
   observer.complete();

--- a/src/observable/from_iter.rs
+++ b/src/observable/from_iter.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
-use std::iter::{Repeat, Take};
+use std::{
+  convert::Infallible,
+  iter::{Repeat, Take},
+};
 
 /// Creates an observable that produces values from an iterator.
 ///
@@ -38,10 +41,10 @@ where
 #[derive(Clone)]
 pub struct ObservableIter<Iter>(Iter);
 
-impl<O, Iter> Observable<Iter::Item, (), O> for ObservableIter<Iter>
+impl<O, Iter> Observable<Iter::Item, Infallible, O> for ObservableIter<Iter>
 where
   Iter: IntoIterator,
-  O: Observer<Iter::Item, ()>,
+  O: Observer<Iter::Item, Infallible>,
 {
   type Unsub = ();
 
@@ -51,7 +54,7 @@ where
   }
 }
 
-impl<Iter> ObservableExt<Iter::Item, ()> for ObservableIter<Iter> where
+impl<Iter> ObservableExt<Iter::Item, Infallible> for ObservableIter<Iter> where
   Iter: IntoIterator
 {
 }

--- a/src/observable/from_stream.rs
+++ b/src/observable/from_stream.rs
@@ -1,6 +1,7 @@
 use futures::{ready, Future, Stream};
 use pin_project_lite::pin_project;
 use std::{
+  convert::Infallible,
   pin::Pin,
   task::{Context, Poll},
 };
@@ -55,10 +56,10 @@ pub struct StreamObservable<S, SD> {
   scheduler: SD,
 }
 
-impl<O, S, SD> Observable<S::Item, (), O> for StreamObservable<S, SD>
+impl<O, S, SD> Observable<S::Item, Infallible, O> for StreamObservable<S, SD>
 where
   S: Stream,
-  O: Observer<S::Item, ()>,
+  O: Observer<S::Item, Infallible>,
   SD: Scheduler<StreamObserverFuture<S, O>>,
 {
   type Unsub = TaskHandle<NormalReturn<()>>;
@@ -70,7 +71,7 @@ where
   }
 }
 
-impl<S, SD> ObservableExt<S::Item, ()> for StreamObservable<S, SD> where
+impl<S, SD> ObservableExt<S::Item, Infallible> for StreamObservable<S, SD> where
   S: Stream
 {
 }
@@ -86,7 +87,7 @@ pin_project! {
 impl<S, O> Future for StreamObserverFuture<S, O>
 where
   S: Stream,
-  O: Observer<S::Item, ()>,
+  O: Observer<S::Item, Infallible>,
 {
   type Output = NormalReturn<()>;
 

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -2,7 +2,10 @@ use crate::{
   prelude::*,
   scheduler::{NormalReturn, RepeatTask, Scheduler, TaskHandle},
 };
-use std::time::{Duration, Instant};
+use std::{
+  convert::Infallible,
+  time::{Duration, Instant},
+};
 
 /// Creates an observable which will fire at `dur` time into the future,
 /// and will repeat every `dur` interval after.
@@ -33,9 +36,9 @@ pub struct IntervalObservable<S> {
   delay: Option<Duration>,
 }
 
-impl<S, O> Observable<usize, (), O> for IntervalObservable<S>
+impl<S, O> Observable<usize, Infallible, O> for IntervalObservable<S>
 where
-  O: Observer<usize, ()>,
+  O: Observer<usize, Infallible>,
   S: Scheduler<RepeatTask<O>>,
 {
   type Unsub = TaskHandle<NormalReturn<()>>;
@@ -46,11 +49,11 @@ where
   }
 }
 
-impl<S> ObservableExt<usize, ()> for IntervalObservable<S> {}
+impl<S> ObservableExt<usize, Infallible> for IntervalObservable<S> {}
 
 fn interval_task<O>(observer: &mut O, seq: usize) -> bool
 where
-  O: Observer<usize, ()>,
+  O: Observer<usize, Infallible>,
 {
   if !observer.is_finished() {
     observer.next(seq);

--- a/src/observable/of.rs
+++ b/src/observable/of.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use crate::prelude::*;
 
 /// Creates an observable producing a multiple values.
@@ -55,9 +57,9 @@ pub fn of<Item>(v: Item) -> OfObservable<Item> {
 #[derive(Clone)]
 pub struct OfObservable<Item>(pub(crate) Item);
 
-impl<Item, O> Observable<Item, (), O> for OfObservable<Item>
+impl<Item, O> Observable<Item, Infallible, O> for OfObservable<Item>
 where
-  O: Observer<Item, ()>,
+  O: Observer<Item, Infallible>,
 {
   type Unsub = ();
 
@@ -67,7 +69,7 @@ where
   }
 }
 
-impl<Item> ObservableExt<Item, ()> for OfObservable<Item> {}
+impl<Item> ObservableExt<Item, Infallible> for OfObservable<Item> {}
 /// Creates an observable that emits value or the error from a [`Result`] given.
 ///
 /// Completes immediately after.
@@ -144,9 +146,9 @@ pub fn of_option<Item>(o: Option<Item>) -> OptionObservable<Item> {
 #[derive(Clone)]
 pub struct OptionObservable<Item>(pub(crate) Option<Item>);
 
-impl<Item, O> Observable<Item, (), O> for OptionObservable<Item>
+impl<Item, O> Observable<Item, Infallible, O> for OptionObservable<Item>
 where
-  O: Observer<Item, ()>,
+  O: Observer<Item, Infallible>,
 {
   type Unsub = ();
 
@@ -158,7 +160,7 @@ where
   }
 }
 
-impl<Item> ObservableExt<Item, ()> for OptionObservable<Item> {}
+impl<Item> ObservableExt<Item, Infallible> for OptionObservable<Item> {}
 
 /// Creates an observable that emits the return value of a callable.
 ///
@@ -186,10 +188,10 @@ where
 #[derive(Clone)]
 pub struct CallableObservable<F>(pub(crate) F);
 
-impl<Item, F, O> Observable<Item, (), O> for CallableObservable<F>
+impl<Item, F, O> Observable<Item, Infallible, O> for CallableObservable<F>
 where
   F: FnOnce() -> Item,
-  O: Observer<Item, ()>,
+  O: Observer<Item, Infallible>,
 {
   type Unsub = ();
 
@@ -199,7 +201,7 @@ where
   }
 }
 
-impl<Item, F> ObservableExt<Item, ()> for CallableObservable<F> where
+impl<Item, F> ObservableExt<Item, Infallible> for CallableObservable<F> where
   F: FnOnce() -> Item
 {
 }

--- a/src/observable/subscribe_item.rs
+++ b/src/observable/subscribe_item.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use crate::prelude::*;
 
 #[derive(Clone)]
@@ -5,7 +7,7 @@ pub struct ObserverItem<N> {
   next: N,
 }
 
-impl<Item, N> Observer<Item, ()> for ObserverItem<N>
+impl<Item, N> Observer<Item, Infallible> for ObserverItem<N>
 where
   N: FnMut(Item),
 {
@@ -14,7 +16,7 @@ where
   }
 
   #[inline]
-  fn error(self, _err: ()) {}
+  fn error(self, _err: Infallible) {}
 
   #[inline]
   fn complete(self) {}
@@ -36,7 +38,7 @@ pub trait ObservableItem<Item, F> {
 
 impl<S, Item, F> ObservableItem<Item, F> for S
 where
-  S: Observable<Item, (), ObserverItem<F>>,
+  S: Observable<Item, Infallible, ObserverItem<F>>,
   F: FnMut(Item),
 {
   type Unsub = S::Unsub;

--- a/src/observable/timer.rs
+++ b/src/observable/timer.rs
@@ -2,7 +2,10 @@ use crate::{
   prelude::*,
   scheduler::{NormalReturn, OnceTask, Scheduler, TaskHandle},
 };
-use std::time::{Duration, Instant};
+use std::{
+  convert::Infallible,
+  time::{Duration, Instant},
+};
 
 // Returns an observable which will emit a single `item`
 // once after a given `dur` using a given `scheduler`
@@ -57,9 +60,9 @@ where
   NormalReturn::new(())
 }
 
-impl<Item, O, S> Observable<Item, (), O> for TimerObservable<Item, S>
+impl<Item, O, S> Observable<Item, Infallible, O> for TimerObservable<Item, S>
 where
-  O: Observer<Item, ()>,
+  O: Observer<Item, Infallible>,
   S: Scheduler<OnceTask<(O, Item), NormalReturn<()>>>,
 {
   type Unsub = TaskHandle<NormalReturn<()>>;
@@ -71,7 +74,7 @@ where
   }
 }
 
-impl<Item, S> ObservableExt<Item, ()> for TimerObservable<Item, S> {}
+impl<Item, S> ObservableExt<Item, Infallible> for TimerObservable<Item, S> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/observable/trivial.rs
+++ b/src/observable/trivial.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use crate::prelude::*;
 
 /// Creates an observable that emits no items, just terminates with an error.
@@ -46,9 +48,9 @@ pub fn empty<Item>() -> EmptyObservable<Item> {
 #[derive(Clone)]
 pub struct EmptyObservable<Item>(TypeHint<Item>);
 
-impl<Item, O> Observable<Item, (), O> for EmptyObservable<Item>
+impl<Item, O> Observable<Item, Infallible, O> for EmptyObservable<Item>
 where
-  O: Observer<Item, ()>,
+  O: Observer<Item, Infallible>,
 {
   type Unsub = ();
 
@@ -57,7 +59,7 @@ where
   }
 }
 
-impl<Item> ObservableExt<Item, ()> for EmptyObservable<Item> {}
+impl<Item> ObservableExt<Item, Infallible> for EmptyObservable<Item> {}
 /// Creates an observable that never emits anything.
 ///
 /// Neither emits a value, nor completes, nor emits an error.
@@ -69,9 +71,9 @@ pub fn never() -> NeverObservable {
 #[derive(Clone)]
 pub struct NeverObservable;
 
-impl<O> Observable<(), (), O> for NeverObservable
+impl<O> Observable<(), Infallible, O> for NeverObservable
 where
-  O: Observer<(), ()>,
+  O: Observer<(), Infallible>,
 {
   type Unsub = ();
 
@@ -80,7 +82,7 @@ where
   }
 }
 
-impl ObservableExt<(), ()> for NeverObservable {}
+impl ObservableExt<(), Infallible> for NeverObservable {}
 #[cfg(test)]
 mod test {
   use crate::prelude::*;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -20,6 +20,7 @@ pub mod merge;
 pub mod merge_all;
 pub mod observe_on;
 pub mod on_complete;
+pub mod on_error;
 pub mod on_error_map;
 pub mod pairwise;
 pub mod ref_count;

--- a/src/ops/box_it.rs
+++ b/src/ops/box_it.rs
@@ -11,7 +11,7 @@ pub trait BoxIt<O>: Sized {
   /// ```
   /// use rxrust::{prelude::*, ops::box_it::BoxOp};
   ///
-  /// let mut boxed: BoxOp<'_, i32, ()> = observable::of(1)
+  /// let mut boxed: BoxOp<'_, i32, _> = observable::of(1)
   ///   .map(|v| v).box_it();
   ///
   /// // BoxOp can box any observable type
@@ -176,7 +176,7 @@ mod test {
   #[test]
   fn box_observable() {
     let mut test = 0;
-    let mut boxed: BoxOp<'_, i32, ()> = observable::of(100).box_it();
+    let mut boxed: BoxOp<'_, i32, _> = observable::of(100).box_it();
     boxed.subscribe(|v| test = v);
 
     boxed = observable::empty().box_it();
@@ -186,7 +186,7 @@ mod test {
 
   #[test]
   fn shared_box_observable() {
-    let mut boxed: BoxOpThreads<i32, ()> = observable::of(100).box_it();
+    let mut boxed: BoxOpThreads<i32, _> = observable::of(100).box_it();
     boxed.subscribe(|_| {});
 
     boxed = observable::empty().box_it();

--- a/src/ops/buffer.rs
+++ b/src/ops/buffer.rs
@@ -319,6 +319,7 @@ mod tests {
       subscriber.error(());
     })
     .buffer_with_time(Duration::from_millis(500), local.spawner())
+    .on_error(|_| {})
     .subscribe(|_| {});
 
     // if this call blocks execution, the observer's handle has not been

--- a/src/ops/on_error.rs
+++ b/src/ops/on_error.rs
@@ -1,0 +1,70 @@
+use std::{convert::Infallible, marker::PhantomData};
+
+use crate::{
+  observable::{Observable, ObservableExt},
+  observer::Observer,
+};
+
+pub struct OnErrorOp<S, F, Err> {
+  pub(crate) source: S,
+  pub(crate) func: F,
+  _marker: PhantomData<Err>,
+}
+
+impl<S, F, Err> OnErrorOp<S, F, Err> {
+  pub fn new(source: S, func: F) -> Self {
+    OnErrorOp { source, func, _marker: PhantomData }
+  }
+}
+
+impl<S, F, Item, Err, O> Observable<Item, Infallible, O>
+  for OnErrorOp<S, F, Err>
+where
+  O: Observer<Item, Infallible>,
+  S: Observable<Item, Err, OnErrorObserver<O, F>>,
+  F: FnOnce(Err),
+{
+  type Unsub = S::Unsub;
+
+  fn actual_subscribe(self, observer: O) -> Self::Unsub {
+    self
+      .source
+      .actual_subscribe(OnErrorObserver { observer, func: self.func })
+  }
+}
+
+impl<S, F, Item, Err> ObservableExt<Item, Infallible> for OnErrorOp<S, F, Err> where
+  S: ObservableExt<Item, Err>
+{
+}
+
+pub struct OnErrorObserver<O, F> {
+  observer: O,
+  func: F,
+}
+
+impl<Item, Err, O, F> Observer<Item, Err> for OnErrorObserver<O, F>
+where
+  O: Observer<Item, Infallible>,
+  F: FnOnce(Err),
+{
+  #[inline]
+  fn next(&mut self, value: Item) {
+    self.observer.next(value)
+  }
+
+  #[inline]
+  fn error(self, err: Err) {
+    (self.func)(err);
+  }
+
+  #[inline]
+  fn complete(self) {
+    self.observer.complete();
+  }
+
+  #[inline]
+  fn is_finished(&self) -> bool {
+    self.observer.is_finished()
+  }
+}

--- a/src/ops/on_error_map.rs
+++ b/src/ops/on_error_map.rs
@@ -118,7 +118,7 @@ mod test {
       publisher.next("Hello");
       publisher.error("World");
     })
-    .on_error_map(|_| ())
+    .on_error(|_| ())
     .subscribe(|_| {});
   }
 

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -300,7 +300,7 @@ mod test {
   fn mut_ref_item() {
     let mut value = 0;
     {
-      let mut subject = MutRefItemSubject::<'_, i32, ()>::default();
+      let mut subject = MutRefItemSubject::<'_, i32, _>::default();
       subject.clone().subscribe(
         (|v| {
           *v = 2;


### PR DESCRIPTION
As commented in #222 `Infallible` should be used instead of `()` for representing errors that can not happen