### PR TITLE
fix: 🐛 changed error type to infallible for from_future

### DIFF
--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -50,7 +50,10 @@ where
   }
 }
 
-impl<F: Future, S> ObservableExt<F::Output, ()> for FutureObservable<F, S> {}
+impl<F: Future, S> ObservableExt<F::Output, Infallible>
+  for FutureObservable<F, S>
+{
+}
 
 fn item_task<Item, O>(item: Item, mut observer: O) -> NormalReturn<()>
 where


### PR DESCRIPTION
Fixed missing change from `()` to `Infallible` in `from_future`.

See: #222