### PR TITLE
feat: add concat_map and concat_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This is a big refactor for rxRust, almost reimplement everything and many api wa
 - **operator**: add `to_stream` operator to convert an observable into a `Stream`.
 - **operator**: add `collect` operator to collect all the items emitted into a collection.
 - **operator**: add `collect_into` operator to collect all the items emitted into a given collection.
+- **operator**: add `concat_map` operator to project each source value to an `Observable`, which is merged in the output `Observable`, in a serialized fashion waiting for each one to complete before merging the next.
+- **operator**: add `concat_all` operator to convert a higher-order `Observable` into a first-order `Observable` by concatenating the inner `Observables` in order.
 - **operator**: add `from_stream` converts an `Stream` into an `Observable`.
 - **operator**: add `from_stream_result` converts an `Stream<Result<Item, Err>` into a fallible `Observable`.
 - **test**: reimplement the `FakeTimer` help us to control the timer when we write unit test.

--- a/missing_features.md
+++ b/missing_features.md
@@ -119,6 +119,9 @@ Operators that operate on the entire sequence of items emitted by an Observable
 
 - [x] Average — calculates the average of numbers emitted by an Observable and emits this average
 - [ ] Concat — emit the emissions from two or more Observables without interleaving them
+  - [ ] Concat
+  - [x] ConcatAll
+  - [x] ConcatMap
 - [x] Count — count the number of items emitted by the source Observable and emit only this value
 - [x] Max — determine, and emit, the maximum-valued item emitted by an Observable
 - [x] Min — determine, and emit, the minimum-valued item emitted by an Observable

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -401,6 +401,63 @@ mod test {
   }
 
   // -------------------------------------------------------------------
+  // testing ConcatMap operator
+  // -------------------------------------------------------------------
+
+  #[test]
+  fn concat_map_identity() {
+    let return_fn = observable::of;
+    let f = |x| observable::of(x + 1);
+    let m = observable::of(0_i32);
+
+    // left identity
+    let partial_left = |x| return_fn(x).concat_map(f);
+    let comp_left = m.clone().concat_map(partial_left);
+
+    // right identity
+    let partial_right = |x| f(x).concat_map(return_fn);
+    let comp_right = m.concat_map(partial_right);
+
+    let mut left: Option<i32> = None;
+    let mut right: Option<i32> = None;
+
+    comp_left.subscribe(|a| left = Some(a));
+    comp_right.subscribe(|b| right = Some(b));
+
+    assert_eq!(left, right);
+  }
+
+  #[test]
+  fn concat_map_associative() {
+    let f = |i: i32| observable::of(i + 1);
+    let g = |i: i32| observable::of(i + 2);
+    let h = |i: i32| observable::of(i + 3);
+    let m = observable::of(0_i32);
+
+    // left association
+    let partial_left = |x| {
+      let partial = f(x).concat_map(g);
+      partial.concat_map(h)
+    };
+    let comp_left = m.clone().concat_map(partial_left);
+
+    // right association
+    let partial_right = |x| {
+      let partial = |y| g(y).concat_map(h);
+      f(x).concat_map(partial)
+    };
+    let comp_right = m.concat_map(partial_right);
+
+    let mut left: Option<i32> = None;
+    let mut right: Option<i32> = None;
+
+    comp_left.subscribe(|a| left = Some(a));
+    comp_right.subscribe(|b| right = Some(b));
+
+    assert_eq!(left, right);
+  }
+
+  // -------------------------------------------------------------------
   // testing FlatMap operator
   // -------------------------------------------------------------------
 


### PR DESCRIPTION
I found this trick from [RxJS's document](https://rxjs.dev/api/operators/concatAll#:~:text=Note%3A%20concatAll%20is%20equivalent%20to%20mergeAll%20with%20concurrency%20parameter%20set%20to%201.):

> Note: [concatAll](https://rxjs.dev/api/index/function/concatAll) is equivalent to [mergeAll](https://rxjs.dev/api/index/function/mergeAll) with concurrency parameter set to 1.

The test case for `concat_all` successfully reproduced RxJS's behavior https://stackblitz.com/edit/zs9ohl?devtoolsheight=50&file=index.ts