### PR TITLE
Derive Clone for ObservableError

### DIFF
--- a/src/ops/future.rs
+++ b/src/ops/future.rs
@@ -12,7 +12,7 @@ use futures::{
 use crate::{observable::Observable, observer::Observer};
 
 /// Errors that can prevent an observable future from resolving correctly.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ObservableError {
   /// The observable had no values.
   Empty,


### PR DESCRIPTION
Not having `Clone` prevents `ObservableError` from being sent between multi-threading observables. It would be nice to provide a `Clone` implementation for `ObservableError`