### PR TITLE
TypeHint<T>: Data race allowed on T

### DIFF
--- a/src/type_hint.rs
+++ b/src/type_hint.rs
@@ -15,8 +15,8 @@ impl<T> Default for TypeHint<T> {
   }
 }
 
-unsafe impl<T> Sync for TypeHint<T> {}
-unsafe impl<T> Send for TypeHint<T> {}
+unsafe impl<T: Sync> Sync for TypeHint<T> {}
+unsafe impl<T: Send> Send for TypeHint<T> {}
 
 impl<T> Clone for TypeHint<T> {
   #[inline]


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`TypeHint<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.

https://github.com/rxRust/rxRust/blob/a54dbd72192c0017b1f2ebc39a9da8939b31858d/src/type_hint.rs#L18-L19