### PR TITLE
Remove `eprintln` on unsubscribe

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -226,7 +226,6 @@ impl<T: Subscription + 'static> Subscription
 {
   fn unsubscribe(self) {
     let mut info = self.0.rc_deref_mut();
-    eprintln!("unsubscribe");
     info.keep_running = false;
     match info.value.take() {
       Some(Ok(v)) => v.0.unsubscribe(),


### PR DESCRIPTION
I suppose it was a remnant from testing that you would print out the unsubscribe event. When using the library it is unfortunate that you get stdout/stderr text to the command line, so I'm removing it from here.