### PR TITLE
RFC: Associate Reference Counting Pointers with Operators based on thread safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a big refactor for rxRust, almost reimplement everything and many api wa
 - `Item` `Err` in `Observer` use generic type instead of associated type.
 - `SubscriptionLike` rename to `Subscription`.
 - removed usage of `()` unit for error that can not happen for `Infallible`
+- Introduced `AssociatedRefPtr` trait in the `rc` mod to `Rc<RefCell<>>` and `Arc<Mutex<>>` pointers with operators based on their thread safety
 
 ### Features
 
@@ -40,6 +41,7 @@ This is a big refactor for rxRust, almost reimplement everything and many api wa
 - **operator**: `delay` operator not really delay the emission but on delay the init subscription.
 - **operator**: `buffer_with_time`, `buffer_with_count_and_time` now return the correct item type.
 - **scheduler**: unsubscribe the handle of parallels scheduler not always cancel the remote task.
+- **behavior subject**: fix cloned behavior subjects holding different versions of their state.
 
 ## [1.0.0-alpha.4](https://github.com/rxRust/rxRust/releases/tag/v1.0.0-alpha.4)
 

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -22,20 +22,38 @@ pub trait RcDerefMut: Clone {
   fn rc_deref_mut(&self) -> Self::MutRef<'_>;
 }
 
+pub trait AssociatedRefPtr {
+
+  type Rc<T>: RcDeref<Target = T> + RcDerefMut<Target = T> + From<T>;
+
+}
+
 #[derive(Default)]
 pub struct MutRc<T>(Rc<RefCell<T>>);
 #[derive(Default)]
 pub struct MutArc<T>(Arc<Mutex<T>>);
 
+impl<T> From<T> for MutArc<T> {
+  fn from(t: T) -> Self {
+    Self(Arc::from(Mutex::from(t)))
+  }
+}
+
+impl<T> From<T> for MutRc<T> {
+  fn from(t: T) -> Self {
+    Self(Rc::from(RefCell::from(t)))
+  }
+}
+
 impl<T> MutArc<T> {
   pub fn own(t: T) -> Self {
-    Self(Arc::new(Mutex::new(t)))
+    Self::from(t)
   }
 }
 
 impl<T> MutRc<T> {
   pub fn own(t: T) -> Self {
-    Self(Rc::new(RefCell::new(t)))
+    Self::from(t)
   }
 }
 

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -23,9 +23,7 @@ pub trait RcDerefMut: Clone {
 }
 
 pub trait AssociatedRefPtr {
-
   type Rc<T>: RcDeref<Target = T> + RcDerefMut<Target = T> + From<T>;
-
 }
 
 #[derive(Default)]

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -11,6 +11,7 @@ use crate::{
 pub mod behavior_subject;
 pub use behavior_subject::*;
 use smallvec::SmallVec;
+use crate::rc::AssociatedRefPtr;
 
 pub trait SubjectSize {
   fn is_empty(&self) -> bool;
@@ -276,6 +277,26 @@ where
   O: for<'i, 'e> Observer<&'i mut Item, &'e mut Err> + 'a,
 {
   impl_observable_for_subject!(Subscriber);
+}
+
+impl<'a, Item, Error> AssociatedRefPtr for Subject<'a, Item, Error> {
+  type Rc<T> = MutRc<T>;
+}
+
+impl<Item, Error> AssociatedRefPtr for SubjectThreads<Item, Error> {
+  type Rc<T> = MutArc<T>;
+}
+
+impl<'a, Item, Error> AssociatedRefPtr for MutRefErrSubject<'a, Item, Error> {
+  type Rc<T> = MutRc<T>;
+}
+
+impl<'a, Item, Error> AssociatedRefPtr for MutRefItemSubject<'a, Item, Error> {
+  type Rc<T> = MutRc<T>;
+}
+
+impl<'a, Item, Error> AssociatedRefPtr for MutRefItemErrSubject<'a, Item, Error> {
+  type Rc<T> = MutRc<T>;
 }
 
 #[cfg(test)]

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 
 pub mod behavior_subject;
+use crate::rc::AssociatedRefPtr;
 pub use behavior_subject::*;
 use smallvec::SmallVec;
-use crate::rc::AssociatedRefPtr;
 
 pub trait SubjectSize {
   fn is_empty(&self) -> bool;
@@ -295,7 +295,9 @@ impl<'a, Item, Error> AssociatedRefPtr for MutRefItemSubject<'a, Item, Error> {
   type Rc<T> = MutRc<T>;
 }
 
-impl<'a, Item, Error> AssociatedRefPtr for MutRefItemErrSubject<'a, Item, Error> {
+impl<'a, Item, Error> AssociatedRefPtr
+  for MutRefItemErrSubject<'a, Item, Error>
+{
   type Rc<T> = MutRc<T>;
 }
 

--- a/src/subject/behavior_subject.rs
+++ b/src/subject/behavior_subject.rs
@@ -11,12 +11,13 @@ impl<Item, Subject: Default + AssociatedRefPtr> BehaviorSubject<Item, Subject> {
   pub fn new(value: Item) -> Self {
     Self {
       subject: <_>::default(),
-      value: value.into()
+      value: value.into(),
     }
   }
 }
 
-impl<Item, Err, Subject: AssociatedRefPtr> Observer<Item, Err> for BehaviorSubject<Item, Subject>
+impl<Item, Err, Subject: AssociatedRefPtr> Observer<Item, Err>
+  for BehaviorSubject<Item, Subject>
 where
   Subject: Observer<Item, Err>,
   Item: Clone,
@@ -43,7 +44,8 @@ where
   }
 }
 
-impl<Item, Subject: AssociatedRefPtr> Subscription for BehaviorSubject<Item, Subject>
+impl<Item, Subject: AssociatedRefPtr> Subscription
+  for BehaviorSubject<Item, Subject>
 where
   Subject: Subscription,
 {
@@ -58,7 +60,8 @@ where
   }
 }
 
-impl<Item, Subject: AssociatedRefPtr> SubjectSize for BehaviorSubject<Item, Subject>
+impl<Item, Subject: AssociatedRefPtr> SubjectSize
+  for BehaviorSubject<Item, Subject>
 where
   Subject: SubjectSize,
 {
@@ -95,7 +98,8 @@ where
 {
 }
 
-impl<Item, Err, Subject: AssociatedRefPtr> Behavior<Item, Err> for BehaviorSubject<Item, Subject>
+impl<Item, Err, Subject: AssociatedRefPtr> Behavior<Item, Err>
+  for BehaviorSubject<Item, Subject>
 where
   Subject: Observer<Item, Err>,
   Item: Clone,
@@ -174,9 +178,9 @@ mod test {
   fn behaviour_keeping_between_clones() {
     let mut vec = Vec::new();
     {
-      let mut behavior_subject = BehaviorSubject::<_, Subject<_, _>>::new(42);
+      let behavior_subject = BehaviorSubject::<_, Subject<_, _>>::new(42);
       behavior_subject.clone().subscribe(|n| vec.push(n));
-      for i in 0..5 {
+      for _ in 0..5 {
         behavior_subject.clone().next_by(|n| n + 1);
       }
     }


### PR DESCRIPTION
# RFC

This pull request includes a new trait called `AssociatedRefPtr` in order to fix #248

### Problem

There are many operators in rxRust with similar functionality, but differentiated on the basis that some are thread safe are others aren't. There has been work done to merge some of them (for example, `LocalBehaviorSubject` and `SharedBehaviorSubject` got merged into `BehaviorSubject`), letting the thread safety be managed by generics. This creates the need for the wrapping operator (e.g. `BehaviorSubject` in this case) to know which reference counting pointer implementation to use in its internal implemetation, the atomic one (`Arc<Mutex<>>` aka. `ArcMut`) or the simple one that's not thread safe (`Rc<RefCell<>>` or `RcMut`), based just on the operator in its generics.

### Specs

The `AssociatedRefPtr` contains only one associated type `Rc` that implements the already existing `RcDeref` and `RcDerefMut` algebraic traits, as well as rust's `From<>` coalgebraic trait. This sufficiently abstracts the monadic interface of a reference counting pointer in rust without knowing which implementation is used, and associates it with an Rx operator based on it thread safety. Now, in an operator composition case like `BehaviorSubject`'s, the wrapping operator can require that the base operator implements the new trait and use its associated `Rc` type when it needs a reference counting pointer.

### Risks

Benefiting from the `AssociatedRefPtr` requires implementing it for a lot of operators, which at best will introduce duplication and at worst break macro implementations. for example, in subject.rs:137:141 there is

```rust
impl_subject_trivial!(Subject<'a, Item,Err>, MutRc, 'a);
impl_subject_trivial!(SubjectThreads< Item, Err>, MutArc);
impl_subject_trivial!(MutRefItemSubject<'a, Item,Err>, MutRc, 'a);
impl_subject_trivial!(MutRefErrSubject<'a, Item,Err>, MutRc, 'a);
impl_subject_trivial!(MutRefItemErrSubject<'a, Item,Err>, MutRc, 'a);
```

which includes implementation details redefined in the trait in the second argument of the macro. Further discussion needs to be done about it.