### PR TITLE
fix: #247 fix combine_latest binary op return type

### DIFF
--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1676,7 +1676,7 @@ pub trait ObservableExt<Item, Err>: Sized {
     self,
     other: Other,
     binary_op: BinaryOp,
-  ) -> CombineLatestOp<Self, Other, BinaryOp>
+  ) -> CombineLatestOp<Self, Other, Item, OtherItem, OutputItem, BinaryOp>
   where
     Other: ObservableExt<OtherItem, Err>,
     BinaryOp: FnMut(Item, OtherItem) -> OutputItem,
@@ -1688,7 +1688,7 @@ pub trait ObservableExt<Item, Err>: Sized {
     self,
     other: Other,
     binary_op: BinaryOp,
-  ) -> CombineLatestOpThread<Self, Other, BinaryOp>
+  ) -> CombineLatestOpThread<Self, Other, Item, OtherItem, OutputItem, BinaryOp>
   where
     Other: ObservableExt<OtherItem, Err>,
     BinaryOp: FnMut(Item, OtherItem) -> OutputItem,


### PR DESCRIPTION
Added a separate `OutputItem` generic for `combine_latest` operator.