### PR TITLE
docs(api): 📚 improve API documentation and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 [![](https://img.shields.io/crates/v/rxrust.svg)](https://crates.io/crates/rxrust)
 [![](https://img.shields.io/crates/d/rxrust.svg)](https://crates.io/crates/rxrust)
 
-**rxRust** is a zero-cost, type-safe Rust implementation of [Reactive Extensions](http://reactivex.io/).
+**rxRust** is a zero-cost, type-safe Rust implementation of [Reactive Extensions](http://reactivex.io/). It brings **Functional Reactive Programming (FRP)** to Rust, enabling a declarative coding style for handling asynchronous events, stream processing, and concurrency.
 
-It enables a declarative coding style for handling asynchronous events, stream processing, and concurrency, leveraging Rust's ownership system to ensure memory safety and efficient resource usage.
+It leverages Rust's ownership system to ensure memory safety and efficient resource usage, making it ideal for build robust event-driven applications.
 
 ## 🚀 Key Features
 
-*   **Zero-Cost Abstractions**: Heavily relies on generic specialization and monomorphization to compile down to efficient code.
+*   **Zero-Cost Abstractions**: Heavily relies on generic specialization and monomorphization to compile down to efficient code, ensuring minimal overhead for your asynchronous streams.
 *   **Pay-for-what-you-need**: Choose the right tool for the job. Use `Local` (Rc/RefCell) for single-threaded performance without locking overhead, or `Shared` (Arc/Mutex) when thread synchronization is actually required.
 *   **Unified Logic, Adaptive Context**: Write your stream logic once. The same operator chains adapt seamlessly to different environments based on the context they run in.
 *   **Interoperability**: Seamlessly integrates with Rust `Future`s, streams, and `async/await`.
@@ -57,7 +57,7 @@ The **Context** determines the execution strategy and memory management:
 *   **`Local`**: **No Locking.** Uses `Rc` and `RefCell`. Ideal for UI threads, WASM, or single-threaded event loops. The compiler ensures these types don't leak across threads.
 *   **`Shared`**: **Thread Safe.** Uses `Arc` and `Mutex`. Required when streams need to jump across threads or share state globally.
 
-![Architecture Diagram](guide/advanced/architecture_diagram.jpeg)
+![rxRust Architecture - Local vs Shared Context](guide/advanced/architecture_diagram.jpeg)
 
 ### 2. Schedulers & Timing
 
@@ -100,7 +100,7 @@ subject.next(2);
 
 ## 📚 Documentation & Guide
 
-For a deeper dive into core concepts, advanced architecture, and cookbooks, check out our **[Online Guide](https://rxrust.github.io/rxRust/)**.
+For a deeper dive into core concepts, advanced architecture, and cookbooks, check out our **[rxRust Online Guide & Documentation](https://rxrust.github.io/rxRust/)**.
 
 *   [Getting Started](guide/getting_started.md)
 *   [Core Concepts](guide/core_concepts/context.md)

--- a/guide/js/version-picker.js
+++ b/guide/js/version-picker.js
@@ -50,6 +50,9 @@
         container.style.textAlign = 'center';
         container.style.borderBottom = '1px solid var(--border-color)';
         container.style.backgroundColor = 'var(--sidebar-bg)';
+        container.style.position = 'sticky';
+        container.style.top = '0';
+        container.style.zIndex = '100';
         container.className = 'version-picker-container';
 
         // Label

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -52,9 +52,9 @@
 //!
 //! | Method | Description | Completion | Values Emitted | Error Emitted |
 //! |--------|-------------|------------|----------------|--------------|
-//! | [`empty()`] | Completes immediately without emitting any values | ✅ Yes | None | None |
-//! | [`never()`] | Never emits any values and never completes | ❌ No | None | None |
-//! | [`throw_err()`] | Immediately emits an error without any values | ❌ No | None | Yes |
+//! | `empty()` | Completes immediately without emitting any values | ✅ Yes | None | None |
+//! | `never()` | Never emits any values and never completes | ❌ No | None | None |
+//! | `throw_err()` | Immediately emits an error without any values | ❌ No | None | Yes |
 //!
 //! ### Use Cases for Trivial Observables
 //!
@@ -190,8 +190,8 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`never()`] - Creates an observable that never completes
-  /// * [`throw_err()`] - Creates an observable that immediately errors
+  /// * [`Self::never`] - Creates an observable that never completes
+  /// * [`Self::throw_err`] - Creates an observable that immediately errors
   /// * [`Empty`] - The underlying observable implementation
   fn empty() -> Self::With<Empty> { Self::lift(Empty) }
 
@@ -222,8 +222,8 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`empty()`] - Creates an observable that completes immediately
-  /// * [`throw_err()`] - Creates an observable that immediately errors
+  /// * [`Self::empty`] - Creates an observable that completes immediately
+  /// * [`Self::throw_err`] - Creates an observable that immediately errors
   /// * [`Never`] - The underlying observable implementation
   fn never() -> Self::With<Never> { Self::lift(Never) }
 
@@ -261,8 +261,8 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`empty()`] - Creates an observable that completes immediately
-  /// * [`never()`] - Creates an observable that never completes
+  /// * [`Self::empty`] - Creates an observable that completes immediately
+  /// * [`Self::never`] - Creates an observable that never completes
   /// * [`ThrowErr`] - The underlying observable implementation
   fn throw_err<E>(error: E) -> Self::With<ThrowErr<E>> { Self::lift(ThrowErr { error }) }
 
@@ -385,8 +385,8 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`of()`] - Creates an observable that emits a single value
-  /// * [`empty()`] - Creates an observable that completes without emitting
+  /// * [`Self::of`] - Creates an observable that emits a single value
+  /// * [`Self::empty`] - Creates an observable that completes without emitting
   ///   values
   /// * [`FromIter`] - The underlying observable implementation
   fn from_iter<I: IntoIterator>(iter: I) -> Self::With<FromIter<I>> { Self::lift(from_iter(iter)) }
@@ -431,9 +431,10 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`of()`] - Creates an observable that emits a predetermined single value
-  /// * [`defer()`] - Creates an observable that generates a new observable at
-  ///   subscription time
+  /// * [`Self::of`] - Creates an observable that emits a predetermined single
+  ///   value
+  /// * [`Self::defer`] - Creates an observable that generates a new observable
+  ///   at subscription time
   /// * [`FromFn`] - The underlying observable implementation
   fn from_fn<F>(f: F) -> Self::With<FromFn<F>> { Self::lift(FromFn(f)) }
 
@@ -448,10 +449,10 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # Key Distinction
   ///
-  /// Unlike [`from_fn()`], which creates an observable that emits a **value**,
-  /// `defer()` creates an observable that emits an entire **observable
-  /// sequence**. This allows for dynamic observable construction based on
-  /// runtime conditions.
+  /// Unlike [`Self::from_fn`], which creates an observable that emits a
+  /// **value**, `defer()` creates an observable that emits an entire
+  /// **observable sequence**. This allows for dynamic observable construction
+  /// based on runtime conditions.
   ///
   /// # Arguments
   ///
@@ -484,9 +485,9 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`from_fn()`] - Generates a **value** at subscription time (emits one
-  ///   item)
-  /// * [`of()`] - Emits a predetermined value (no lazy evaluation)
+  /// * [`Self::from_fn`] - Generates a **value** at subscription time (emits
+  ///   one item)
+  /// * [`Self::of`] - Emits a predetermined value (no lazy evaluation)
   /// * [`Defer`] - The underlying observable implementation
   fn defer<F, O>(f: F) -> Self::With<Defer<F, O>>
   where
@@ -516,8 +517,8 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`timer_with()`] - Same functionality with custom scheduler
-  /// * [`delay()`] - Delays emissions from an existing observable
+  /// * [`Self::timer_with`] - Same functionality with custom scheduler
+  /// * `delay()` - Delays emissions from an existing observable
   fn timer(delay: Duration) -> Self::With<Timer<Self::Scheduler>> {
     Self::lift(Timer { delay, scheduler: Self::Scheduler::default() })
   }
@@ -525,9 +526,9 @@ pub trait ObservableFactory: Context<Inner = ()> {
   /// Creates an observable that emits a single value after a specified delay,
   /// using a custom scheduler.
   ///
-  /// Same as [`timer()`], but uses a custom scheduler instead of the default
-  /// one. Useful for using `SharedScheduler` in `Local` context or for
-  /// specific scheduling behavior.
+  /// Same as [`Self::timer`], but uses a custom scheduler instead of the
+  /// default one. Useful for using `SharedScheduler` in `Local` context or
+  /// for specific scheduling behavior.
   ///
   /// # Examples
   ///
@@ -576,8 +577,8 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`interval_with()`] - Same functionality with custom scheduler
-  /// * [`timer()`] - Emits a single value after a delay
+  /// * [`Self::interval_with`] - Same functionality with custom scheduler
+  /// * [`Self::timer`] - Emits a single value after a delay
   fn interval(period: Duration) -> Self::With<Interval<Self::Scheduler>> {
     Self::lift(Interval { period, scheduler: Self::Scheduler::default() })
   }
@@ -585,8 +586,8 @@ pub trait ObservableFactory: Context<Inner = ()> {
   /// Creates an observable that emits sequential numbers at regular intervals,
   /// using a custom scheduler.
   ///
-  /// Same as [`interval()`], but uses a custom scheduler instead of the default
-  /// one.
+  /// Same as [`Self::interval`], but uses a custom scheduler instead of the
+  /// default one.
   ///
   /// # Examples
   ///
@@ -965,7 +966,7 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`concat_observables`] - Sequential subscription (one at a time)
+  /// * [`Self::concat_observables`] - Sequential subscription (one at a time)
   /// * [`Observable::merge`] - Instance method for merging two observables
   fn merge_observables<O, I>(
     observables: I,
@@ -1031,7 +1032,7 @@ pub trait ObservableFactory: Context<Inner = ()> {
   ///
   /// # See Also
   ///
-  /// * [`merge_observables`] - Concurrent subscription (all at once)
+  /// * [`Self::merge_observables`] - Concurrent subscription (all at once)
   /// * [`Observable::concat_all`] - Flatten a higher-order observable
   ///   sequentially
   fn concat_observables<O, I>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,48 @@
 #![cfg_attr(feature = "nightly", feature(fn_traits, unboxed_closures))]
-//! Reactive extensions library for Rust: a library for
-//! [Reactive Programming](http://reactivex.io/) using
-//! [Observable](crate::observable::Observable), to make
-//! it easier to compose asynchronous or callback-based code.
-#[cfg_attr(not(target_arch = "wasm32"), doc = include_str!("../README.md"))]
+//! # rxRust: Reactive Extensions for Rust
+//!
+//! Zero-cost, type-safe implementation of [Reactive Extensions](http://reactivex.io/).
+//!
+//! ## Quick Start
+//!
+//! ```rust
+//! use rxrust::prelude::*;
+//!
+//! // Local context: No locks, optimal for single-thread
+//! Local::from_iter(0..10)
+//!   .filter(|v| v % 2 == 0)
+//!   .map(|v| v * 2)
+//!   .subscribe(|v| println!("Value: {}", v));
+//! ```
+//!
+//! ## Key Concepts
+//!
+//! | Type | Description |
+//! |------|-------------|
+//! | [`Local`] / [`Shared`] | Execution contexts (single-thread vs thread-safe) |
+//! | [`Observable`] | The core trait defining stream operations |
+//! | [`Observer`] | Consumes `next`, `error`, and `complete` events |
+//! | [`Subscription`] | Handle to cancel an active subscription |
+//!
+//! ## 📚 Documentation
+//!
+//! For comprehensive guides, see the **[Online Guide](https://rxrust.github.io/rxRust/)**:
+//!
+//! - [Getting Started](https://rxrust.github.io/rxRust/getting_started.html)
+//! - [Core Concepts](https://rxrust.github.io/rxRust/core_concepts.html)
+//! - [Operators Reference](https://rxrust.github.io/rxRust/operators.html)
+//! - [Cookbook](https://rxrust.github.io/rxRust/cookbook.html)
+//!
+//! ## Feature Flags
+//!
+//! - **`scheduler`** (default): Tokio-based schedulers for timing operators
+//! - **`nightly`**: Experimental features requiring nightly Rust
+//!
+//! [`Local`]: prelude::Local
+//! [`Shared`]: prelude::Shared
+//! [`Observable`]: observable::Observable
+//! [`Observer`]: observer::Observer
+//! [`Subscription`]: subscription::Subscription
 #[cfg(test)]
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen::prelude::wasm_bindgen(start)]

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1121,8 +1121,8 @@ pub trait Observable: Context {
   ///
   /// * `policy` - The retry policy. This can be:
   ///   - `usize`: A simple retry count (e.g., `.retry(3)`).
-  ///   - [`RetryConfig`]: A configuration object for advanced control (delay,
-  ///     reset on success).
+  ///   - [`crate::ops::RetryConfig`]: A configuration object for advanced
+  ///     control (delay, reset on success).
   ///   - A custom type implementing the [`RetryPolicy`] trait.
   ///
   /// # Examples

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,7 +1,32 @@
-//! Operator implementations
+//! # Operators
 //!
-//! This module contains all operator implementations (Map, Filter, Merge,
-//! etc.).
+//! All operator implementations for transforming, filtering, and combining
+//! observable streams.
+//!
+//! ## Operator Categories
+//!
+//! ### Transformation
+//! - [`map`] - Transform each item
+//! - [`filter_map`] - Transform and filter in one step
+//! - [`scan`] - Accumulate with intermediate emissions
+//!
+//! ### Filtering
+//! - [`filter`] - Pass items matching a predicate
+//! - [`take`] / [`skip`] - Limit emissions
+//! - [`distinct`] - Remove duplicates
+//!
+//! ### Combination
+//! - [`merge`] - Interleave multiple streams
+//! - [`zip`] - Pair items from multiple streams
+//! - [`combine_latest`] - Combine latest values
+//!
+//! ### Timing
+//! - [`debounce`] - Emit after quiet period
+//! - [`throttle`] - Rate limit emissions
+//! - [`delay`] - Shift emissions in time
+//!
+//! For interactive marble diagrams, see [ReactiveX.io](http://reactivex.io/documentation/operators.html).
+//! For Rust-specific usage, see the [Operators Guide](https://rxrust.github.io/rxRust/operators.html).
 
 pub mod average;
 pub mod box_it;

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -18,6 +18,7 @@ use crate::{
 /// Emits an item from the source Observable only after a particular duration
 /// has passed without another source emission. Each new emission resets the
 /// timer.
+#[doc(alias = "debounceTime")]
 #[derive(Clone)]
 pub struct Debounce<S, Sch> {
   pub source: S,

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -26,6 +26,7 @@ use crate::{
 /// });
 /// assert_eq!(result, vec![2, 4]);
 /// ```
+#[doc(alias = "where")]
 #[derive(Clone)]
 pub struct Filter<S, F> {
   pub source: S,

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -29,6 +29,8 @@ use crate::{
 /// });
 /// assert_eq!(result, Some(84));
 /// ```
+#[doc(alias = "select")]
+#[doc(alias = "transform")]
 #[derive(Clone)]
 pub struct Map<S, F> {
   pub source: S,


### PR DESCRIPTION
- Replace README include with dedicated crate-level docs in `lib.rs` including Quick Start
- Fix intra-doc links in `ObservableFactory` and `observable.rs`
- Add categorized overview to `ops` module documentation
- Add `doc(alias)` attributes to `map`, `filter`, and `debounce` for better IDE discovery