### PR TITLE
fix 264

### DIFF
--- a/guide/core_concepts/type_erasure.md
+++ b/guide/core_concepts/type_erasure.md
@@ -1,6 +1,6 @@
 # Type Erasure
 
-One common challenge when working with RxRust (and Rust iterators/futures in general) is the rapidly growing complexity of types.
+One common challenge when working with rxRust (and Rust iterators/futures in general) is the rapidly growing complexity of types.
 
 ## The Problem: Type Explosion
 
@@ -9,7 +9,7 @@ Every operator you apply wraps the previous Observable in a new struct.
 ```rust
 use rxrust::prelude::*;
 
-// Type: LocalObservable<Map<Filter<Range, ...>, ...>, ...>
+// Type: Local<Map<Filter<FromIter<...>, ...>, ...>>
 let stream = Local::from_iter(0..10)
     .filter(|v| v % 2 == 0)
     .map(|v| v * 2);
@@ -19,58 +19,94 @@ While these types are usually inferred by the compiler, they become problematic 
 1. Return an Observable from a function.
 2. Store an Observable in a struct.
 3. Conditionally return different Observable chains.
+4. Store heterogeneous observables in a collection.
 
-## Solution 1: `impl Observable` (Zero Cost)
+## The Solution: `box_it()` (Type Erasure)
 
-If you are returning an Observable from a function, the preferred way is to use `impl Observable`. This keeps the concrete type hidden but maintains static dispatch (zero runtime overhead).
+When you need to store an Observable or return different types from different branches, use **Type Erasure** via the `.box_it()` operator. This boxes the observable, unifying the type at the cost of heap allocation and dynamic dispatch.
+
+### Basic Usage
 
 ```rust
 use rxrust::prelude::*;
 use std::convert::Infallible;
 
-fn create_stream() -> impl for<'a> Observable<Item<'a> = i32, Err = Infallible> {
-    Local::from_iter(0..10)
-        .filter(|v| v % 2 == 0)
-        .map(|v| v * 2)
+fn create_dynamic_stream(condition: bool) -> LocalBoxedObservable<'static, i32, Infallible> {
+    if condition {
+        Local::of(1).box_it()
+    } else {
+        Local::from_iter(0..10).map(|v| v * 2).box_it()
+    }
+}
+
+fn main() {
+    let stream = create_dynamic_stream(true);
+    stream.subscribe(|v| println!("{}", v));
 }
 ```
 
-**Pros:**
-- Zero runtime cost.
-- No heap allocation.
-
-**Cons:**
-- Cannot be stored in a struct field (unless generic).
-- All code paths must return the exact same concrete type.
-
-## Solution 2: `box_it()` (Dynamic Dispatch)
-
-When you need to store an Observable or return different types from different branches, you need **Type Erasure**. The `.box_it()` operator boxes the observable, unifying the type to `LocalBoxedObservable` (or `SharedBoxedObservable`).
+### Storing in Collections
 
 ```rust
 use rxrust::prelude::*;
+use std::convert::Infallible;
 
-fn create_dynamic_stream(condition: bool) -> LocalBoxedObservable<'static, i32, ()> {
-    if condition {
-        Local::of(1).map_err(|_| ()).box_it()
-    } else {
-        Local::from_iter(0..10).map(|v| v * 2).map_err(|_| ()).box_it()
-    }
+// Different source types become the same boxed type
+let boxed1: LocalBoxedObservable<'_, i32, Infallible> = Local::of(1).box_it();
+let boxed2: LocalBoxedObservable<'_, i32, Infallible> = 
+    Local::from_iter([2, 3]).map(|x| x * 2).box_it();
+
+// Now they can be stored together
+let observables = vec![boxed1, boxed2];
+
+for obs in observables {
+    obs.subscribe(|v| println!("{}", v));
 }
 ```
 
 **Pros:**
-- Returns a unified concrete type (one of the 4 boxed variants, e.g., `LocalBoxedObservable`).
-- Can be stored in structs easily.
+- Returns a unified concrete type.
+- Can be stored in structs and collections easily.
+- Works across conditional branches.
 
-### Cloneable boxed observables: `box_it_clone()` / `box_it_mut_ref_clone()`
+**Cons:**
+- Heap allocation for the boxed observable.
+- Dynamic dispatch overhead (usually negligible).
 
-The regular `box_it()` result is not `Clone`, because a boxed trait object
-cannot be cloned unless the underlying observable pipeline is cloneable.
+> **Note on Error Types**: When using `.subscribe(|v| ...)` with a simple closure, the observable's error type must be `Infallible`. This is because the closure-based subscription cannot handle errors. If you need a different error type, use `.subscribe_with()` with a full `Observer` implementation.
 
-If you need a boxed observable that can be cloned (for example, to keep a
-template observable in a struct and create copies for multiple independent
-subscriptions), use `box_it_clone()`.
+## Boxed Type Variants
+
+rxRust provides multiple boxed observable types to cover different use cases:
+
+### By Context (Local vs Shared)
+
+| Context | Type | Created with |
+|---------|------|--------------|
+| Local (single-threaded) | `LocalBoxedObservable<'a, Item, Err>` | `Local::...box_it()` |
+| Shared (multi-threaded) | `SharedBoxedObservable<'a, Item, Err>` | `Shared::...box_it()` |
+
+### By Item Type (Value vs Mutable Reference)
+
+| Item Type | Method | Result Type |
+|-----------|--------|-------------|
+| Owned values (`T`) | `.box_it()` | `LocalBoxedObservable` / `SharedBoxedObservable` |
+| Mutable references (`&mut T`) | `.box_it_mut_ref()` | `LocalBoxedObservableMutRef` / `SharedBoxedObservableMutRef` |
+
+### By Cloneability
+
+| Cloneable? | Method | Result Type |
+|------------|--------|-------------|
+| No | `.box_it()` | `LocalBoxedObservable` |
+| Yes | `.box_it_clone()` | `LocalBoxedObservableClone` |
+| No (mut ref) | `.box_it_mut_ref()` | `LocalBoxedObservableMutRef` |
+| Yes (mut ref) | `.box_it_mut_ref_clone()` | `LocalBoxedObservableMutRefClone` |
+
+## Cloneable Boxed Observables
+
+The regular `box_it()` result is **not** `Clone`, because a boxed trait object cannot be cloned unless the underlying observable pipeline is cloneable.
+
+If you need a boxed observable that can be cloned (for example, to keep a template observable and create copies for multiple independent subscriptions), use `box_it_clone()`.
 
 ```rust
 use rxrust::prelude::*;
@@ -95,15 +131,64 @@ fn main() {
 }
 ```
 
-For observables that emit mutable references (`Item = &'a mut T`), use
-`box_it_mut_ref_clone()`.
+## Mutable Reference Observables
+
+For observables that emit mutable references (`Item = &'a mut T`), use the `_mut_ref` variants:
+
+```rust
+use std::convert::Infallible;
+use rxrust::prelude::*;
+
+// Create a subject that emits mutable references
+let subject = Local::subject_mut_ref::<i32, Infallible>();
+
+// Box it for type erasure
+let boxed = subject.clone().box_it_mut_ref();
+
+// Or if you need it to be cloneable:
+let boxed_clone = subject.clone().box_it_mut_ref_clone();
+```
+
+## Shared Context Example
+
+For multi-threaded scenarios, use the `Shared` context:
+
+```rust
+use rxrust::prelude::*;
+use std::convert::Infallible;
+
+fn create_shared_stream(condition: bool) -> SharedBoxedObservable<'static, i32, Infallible> {
+    if condition {
+        Shared::of(1).box_it()
+    } else {
+        Shared::from_iter(0..10).map(|v| v * 2).box_it()
+    }
+}
+
+// The returned observable can be sent across threads
+```
+
+## Complete Type Reference
+
+| Context | Cloneable | Item Type | Type Alias |
+|---------|-----------|-----------|------------|
+| Local | No | `T` | `LocalBoxedObservable<'a, Item, Err>` |
+| Local | Yes | `T` | `LocalBoxedObservableClone<'a, Item, Err>` |
+| Local | No | `&mut T` | `LocalBoxedObservableMutRef<'a, Item, Err>` |
+| Local | Yes | `&mut T` | `LocalBoxedObservableMutRefClone<'a, Item, Err>` |
+| Shared | No | `T` | `SharedBoxedObservable<'a, Item, Err>` |
+| Shared | Yes | `T` | `SharedBoxedObservableClone<'a, Item, Err>` |
+| Shared | No | `&mut T` | `SharedBoxedObservableMutRef<'a, Item, Err>` |
+| Shared | Yes | `&mut T` | `SharedBoxedObservableMutRefClone<'a, Item, Err>` |
 
 ## Summary
 
 | Scenario | Recommendation |
 |----------|----------------|
-| Function return type | `impl Observable` |
-| Conditional branches | `box_it()` |
-| Struct fields | `box_it()` or Generic parameters |
-| API boundaries | `box_it()` (usually easier for consumers) |
-| Need `Clone` on boxed observable | `box_it_clone()` / `box_it_mut_ref_clone()` |
+| Return different types from branches | `box_it()` |
+| Store Observable in struct fields | `box_it()` |
+| API boundaries | `box_it()` (easier for consumers) |
+| Collections of heterogeneous observables | `box_it()` |
+| Need `Clone` on boxed observable | `box_it_clone()` |
+| Mutable reference observables | `box_it_mut_ref()` / `box_it_mut_ref_clone()` |
+| Multi-threaded / cross-thread usage | Use `Shared::...box_it()` |

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -1092,10 +1092,11 @@ mod tests {
   }
 
   impl<T> Context for CustomContext<T> {
+    type Scope = LocalScope;
     type Inner = T;
     type Scheduler = CustomTestScheduler;
-    type RcMut<U> = MutRc<U>; // Use MutRc since it's single-threaded like Local
-    type RcCell<U: Copy + Eq> = CellRc<U>; // Use CellRc for Copy types
+    type RcMut<U> = MutRc<U>;
+    type RcCell<U: Copy + Eq> = CellRc<U>;
     type With<U> = CustomContext<U>;
     type BoxedObserver<'a, Item, Err> = BoxedObserver<'a, Item, Err>;
     type BoxedObserverMutRef<'a, Item: 'a, Err> = BoxedObserverMutRef<'a, Item, Err>;

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -6,7 +6,7 @@
 
 use std::convert::Infallible;
 
-use crate::context::{MutArc, MutRc, RcDeref, RcDerefMut};
+use crate::context::RcDerefMut;
 
 // ============================================================================
 // Observer Trait
@@ -306,33 +306,11 @@ where
   fn is_closed(&self) -> bool { self.as_ref().is_none_or(Observer::is_closed) }
 }
 
-/// MutRc<Option<O>> - shared ownership observer for local context
-/// Uses take() for terminal operations to consume the inner observer
-impl<O, Item, Err> Observer<Item, Err> for MutRc<Option<O>>
+/// MutRc<Option<O>> & MutArc<Option<O>> - shared ownership observer for local
+/// context Uses take() for terminal operations to consume the inner observer
+impl<O, Item, Err, P> Observer<Item, Err> for P
 where
-  O: Observer<Item, Err>,
-{
-  fn next(&mut self, value: Item) { self.rc_deref_mut().next(value); }
-
-  fn error(self, err: Err) {
-    if let Some(inner) = self.rc_deref_mut().take() {
-      inner.error(err);
-    }
-  }
-
-  fn complete(self) {
-    if let Some(inner) = self.rc_deref_mut().take() {
-      inner.complete();
-    }
-  }
-
-  fn is_closed(&self) -> bool { self.rc_deref().is_none() }
-}
-
-/// MutArc<Option<O>> - shared ownership observer for shared context
-/// Uses take() for terminal operations to consume the inner observer
-impl<O, Item, Err> Observer<Item, Err> for MutArc<Option<O>>
-where
+  P: RcDerefMut<Target = Option<O>>,
   O: Observer<Item, Err>,
 {
   fn next(&mut self, value: Item) { self.rc_deref_mut().next(value); }


### PR DESCRIPTION
- **refactor(observer): ♻️ unify shared ownership observer implementations**
- **refactor(context): ♻️ introduce Scope trait to decouple environment capabilities**
- **docs(guide): 📚 rewrite and expand type erasure documentation**
