### PR TITLE
docs: 📚 update feedback loop examples and document map design

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,14 +11,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # 快速检查 - 代码格式和编译错误
   format:
     name: Code Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: nightly-2025-12-20
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -27,8 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: nightly-2025-12-20
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features -- -D warnings
@@ -58,8 +59,6 @@ jobs:
           PY
           )
           echo "features=$FEATURES" >> "$GITHUB_OUTPUT"
-
-  # 编译检查
   check:
     name: Cargo Check (stable)
     runs-on: ubuntu-latest
@@ -79,7 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2025-12-20
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-features
       - run: cargo check --all-features --lib
@@ -87,7 +88,6 @@ jobs:
           RUSTFLAGS: ""
           CARGO_ENCODED_RUSTFLAGS: ""
 
-  # 测试
   test:
     name: Tests (stable)
     runs-on: ubuntu-latest
@@ -104,11 +104,12 @@ jobs:
     needs: check-nightly
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly-2025-12-20
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
 
-  # WASM 测试
   test-wasm:
     name: WASM Tests
     runs-on: ubuntu-latest
@@ -116,12 +117,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - run: wasm-pack test --node
 
-  # 汇总检查 - 用于分支保护规则
   ci:
     name: CI Status
     runs-on: ubuntu-latest

--- a/examples/custom_scheduler.rs
+++ b/examples/custom_scheduler.rs
@@ -4,8 +4,6 @@
 //! We define a custom scheduler that logs events and executes tasks immediately
 //! (blocking the thread for delays), and then inject it into rxRust.
 
-use std::time::Duration;
-
 use rxrust::{
   prelude::*,
   scheduler::{Schedulable, Scheduler, SleepProvider, TaskHandle},

--- a/guide/advanced/custom_scheduling.md
+++ b/guide/advanced/custom_scheduling.md
@@ -32,7 +32,6 @@ First, define your scheduler struct. You need to implement two traits:
 ```rust,ignore
 use rxrust::prelude::*;
 use rxrust::scheduler::{Scheduler, Schedulable, TaskHandle, SleepProvider};
-use std::time::Duration;
 
 #[derive(Clone, Default)]
 pub struct MyGameScheduler;

--- a/guide/async_interop.md
+++ b/guide/async_interop.md
@@ -88,7 +88,7 @@ Rust's standard `Stream` trait is a pull-based asynchronous iterator. `from_stre
 ```rust,no_run
 use rxrust::prelude::*;
 use futures::stream::{self, StreamExt};
-use tokio::time::{sleep, Duration};
+use tokio::time::sleep;
 
 #[tokio::main]
 async fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 #![cfg_attr(feature = "nightly", feature(fn_traits, unboxed_closures))]
+// The nightly-only `fn_traits` support is intentionally kept as the primary
+// path for lifetime-dependent `map` outputs. Replacing it wholesale with a
+// library-defined callable trait degrades type inference for ordinary closures,
+// most visibly at `subscribe` call sites, and the pain spreads across operator
+// chains.
 //! # rxRust: Reactive Extensions for Rust
 //!
 //! Zero-cost, type-safe implementation of [Reactive Extensions](http://reactivex.io/).

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -169,6 +169,13 @@ pub trait Observable: Context {
     self.transform(|core| Map { source: core, func: f })
   }
 
+  // Keep the nightly `FnMut<(...)>` path here instead of replacing it with a
+  // custom callable trait. A custom trait can model the lifetime-dependent
+  // output for `map` itself, but it breaks closure inference further
+  // downstream, especially for `subscribe`, and that damage compounds across an
+  // operator chain. If we revisit stable support here, prefer a narrow,
+  // explicit API rather than swapping the whole closure ecosystem over to a
+  // library-defined trait.
   #[cfg(feature = "nightly")]
   fn map<F>(self, f: F) -> Self::With<Map<Self::Inner, F>>
   where

--- a/src/ops/buffer_time.rs
+++ b/src/ops/buffer_time.rs
@@ -180,7 +180,7 @@ where
 
 #[cfg(test)]
 mod tests {
-  use std::{cell::RefCell, rc::Rc, time::Duration};
+  use std::{cell::RefCell, rc::Rc};
 
   use crate::prelude::*;
 

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -95,6 +95,10 @@ where
   S: ObservableType,
   F: for<'a> FnMut<(S::Item<'a>,)>,
 {
+  // Do not "stabilize" this by swapping to a custom callable trait here.
+  // That approach type-checks for `map` in isolation, but it weakens the
+  // compiler's built-in closure inference and quickly forces explicit
+  // annotations at subscribe sites and in longer operator chains.
   type Item<'a>
     = <F as FnOnce<(S::Item<'a>,)>>::Output
   where

--- a/src/ops/throttle.rs
+++ b/src/ops/throttle.rs
@@ -426,8 +426,6 @@ where
 
 #[cfg(test)]
 mod tests {
-  use std::time::Duration;
-
   use super::*;
   use crate::prelude::*;
 

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -67,26 +67,40 @@
 //! - **Subscription mutations are allowed** (`subscribe`/`unsubscribe`) inside
 //!   callbacks. They may be applied after the current emission finishes.
 //!
-//! If you intentionally need feedback loops, insert an explicit async boundary
-//! (e.g. `delay(Duration::from_millis(0))`).
+//! If you intentionally need feedback loops (emitting values from within a
+//! callback), insert an explicit async boundary using `delay`:
 //!
-//! ```rust
-//! use std::time::Duration;
+//! ```rust,no_run
+//! # #[cfg(not(target_arch = "wasm32"))]
+//! # {
+//! use std::convert::Infallible;
 //!
 //! use rxrust::prelude::*;
 //!
-//! let subject = Local::subject();
-//! let s_clone = subject.clone();
+//! # #[tokio::main]
+//! # async fn main() {
+//! let mut subject = Shared::subject::<i32, Infallible>();
+//! let mut emitter = subject.clone();
 //!
-//! let subscription = subject.clone().subscribe(move |_: ()| {
-//!   // CORRECT: Insert an explicit async boundary before emitting.
-//!   s_clone
-//!     .clone()
-//!     .delay(Duration::from_millis(0))
-//!     .subscribe(|_| println!("Runs on a later tick"));
-//! });
+//! // Apply delay(0) to the observable chain to create an async boundary.
+//! // This schedules the callback on the next scheduler tick, after the
+//! // original emission has completed and the Subject's internal borrow
+//! // has been released.
+//! subject
+//!   .clone()
+//!   .delay(Duration::from_millis(0))
+//!   .subscribe(move |n| {
+//!     println!("Received: {}", n);
+//!     if n < 3 {
+//!       // Safe: delay(0) ensures we're on a new scheduler tick
+//!       emitter.next(n + 1);
+//!     }
+//!   });
 //!
-//! subscription.unsubscribe();
+//! subject.next(0);
+//! tokio::time::sleep(Duration::from_millis(100)).await;
+//! # }
+//! # }
 //! ```
 
 pub mod behavior_subject;

--- a/src/subject/subject_core.rs
+++ b/src/subject/subject_core.rs
@@ -301,22 +301,38 @@ pub type SharedSubjectMutRef<'a, Item, Err> = Shared<InnerSubjectMutRefSend<'a, 
 /// });
 /// ```
 ///
-/// ### Example: explicit async boundary (works)
+/// ### Example: explicit async boundary for feedback loops
+///
+/// To safely emit values from within a callback, apply `delay(0)` to the
+/// observable chain. This schedules the callback on the next scheduler tick,
+/// breaking the synchronous call chain:
 ///
 /// ```rust,no_run
-/// use std::{convert::Infallible, time::Duration};
+/// # #[cfg(not(target_arch = "wasm32"))]
+/// # {
+/// use std::convert::Infallible;
 ///
 /// use rxrust::prelude::*;
 ///
-/// let subject = Local::subject::<i32, Infallible>();
-/// let s_clone = subject.clone();
+/// # #[tokio::main]
+/// # async fn main() {
+/// let mut subject = Shared::subject::<i32, Infallible>();
+/// let mut emitter = subject.clone();
 ///
-/// subject.clone().subscribe(move |_| {
-///   s_clone
-///     .clone()
-///     .delay(Duration::from_millis(0))
-///     .subscribe(|_| println!("Runs on a later tick"));
-/// });
+/// subject
+///   .clone()
+///   .delay(Duration::from_millis(0)) // Creates async boundary
+///   .subscribe(move |n| {
+///     println!("Received: {}", n);
+///     if n < 3 {
+///       emitter.next(n + 1); // Safe: now on a new scheduler tick
+///     }
+///   });
+///
+/// subject.next(0);
+/// tokio::time::sleep(Duration::from_millis(100)).await;
+/// # }
+/// # }
 /// ```
 pub struct Subject<P> {
   pub observers: P,


### PR DESCRIPTION
### **Summary**

This PR improves the documentation for feedback loops and provides design rationale for the `map` operator's implementation. It also updates `Subject` examples to ensure compatibility with `Shared` subjects and async environments.

### **Changes**

- **Feedback Loop Documentation**: Updated examples for `Subject` and `subject_core` to demonstrate safe feedback loops using `delay(0)`.
- **Map Design Rationale**: Added internal documentation explaining the preference for `fn_traits` over custom traits in `map` outputs to preserve type inference.
- **Subject Examples**: Refactored `Subject` documentation tests to use `Shared` subjects with appropriate async setups, ensuring they reflect recommended usage patterns.
