### PR TITLE
test: test_from_future_async_block_flat_map

### DIFF
--- a/tests/v1_integration.rs
+++ b/tests/v1_integration.rs
@@ -133,6 +133,18 @@ fn test_merge_integration() {
 }
 
 #[rxrust_macro::test]
+fn test_from_future_async_block_flat_map() {
+  let result = Rc::new(RefCell::new(None));
+  let result_clone = result.clone();
+
+  Local::of(Local::from_future(async { 42_u8 }))
+    .flat_map(|v| v)
+    .subscribe(move |v| *result_clone.borrow_mut() = Some(v));
+
+  assert_eq!(*result.borrow(), Some(42));
+}
+
+#[rxrust_macro::test]
 fn test_zip_integration() {
   // Test zipping two observables
   let results = Rc::new(RefCell::new(Vec::new()));


### PR DESCRIPTION
Hey, shouldn't this pass type checking?

```
   Compiling rxrust v1.0.0-rc.3 (/home/mightyiam/worktrees/rxRust)
error[E0599]: the method `subscribe` exists for struct `LocalCtx<MergeAll<Map<Of<LocalCtx<FromFuture<..., ...>, ...>>, ...>>, ...>`, but its trait bounds were not satisfied
   --> tests/v1_integration.rs:142:6
    |
140 | /   Local::of(Local::from_future(async { 42_u8 }))
141 | |     .flat_map(|v| v)
142 | |     .subscribe(move |v| *result_clone.borrow_mut() = Some(v));
    | |     -^^^^^^^^^ method cannot be called due to unsatisfied trait bounds
    | |_____|
    |
    |
   ::: src/context.rs:170:1
    |
170 |   pub struct LocalCtx<T, S> {
    |   ------------------------- doesn't satisfy `_: Observable`
    |
   ::: src/ops/merge_all.rs:36:1
    |
 36 |   pub struct MergeAll<S> {
    |   ---------------------- doesn't satisfy `_: ObservableType`
    |
    = note: the following trait bounds were not satisfied:
            `MergeAll<rxrust::ops::Map<Of<LocalCtx<FromFuture<{async block@tests/v1_integration.rs:140:32: 140:37}, LocalScheduler>, LocalScheduler>>, {closure@tests/v1_integration.rs:141:15: 141:18}>>: ObservableType`
            which is required by `LocalCtx<MergeAll<rxrust::ops::Map<Of<LocalCtx<FromFuture<{async block@tests/v1_integration.rs:140:32: 140:37}, LocalScheduler>, LocalScheduler>>, {closure@tests/v1_integration.rs:141:15: 141:18}>>, LocalScheduler>: rxrust::Observable`
            `&LocalCtx<MergeAll<rxrust::ops::Map<Of<LocalCtx<FromFuture<{async block@tests/v1_integration.rs:140:32: 140:37}, LocalScheduler>, LocalScheduler>>, {closure@tests/v1_integration.rs:141:15: 141:18}>>, LocalScheduler>: rxrust::Context`
            which is required by `&LocalCtx<MergeAll<rxrust::ops::Map<Of<LocalCtx<FromFuture<{async block@tests/v1_integration.rs:140:32: 140:37}, LocalScheduler>, LocalScheduler>>, {closure@tests/v1_integration.rs:141:15: 141:18}>>, LocalScheduler>: rxrust::Observable`
            `&mut LocalCtx<MergeAll<rxrust::ops::Map<Of<LocalCtx<FromFuture<{async block@tests/v1_integration.rs:140:32: 140:37}, LocalScheduler>, LocalScheduler>>, {closure@tests/v1_integration.rs:141:15: 141:18}>>, LocalScheduler>: rxrust::Context`
            which is required by `&mut LocalCtx<MergeAll<rxrust::ops::Map<Of<LocalCtx<FromFuture<{async block@tests/v1_integration.rs:140:32: 140:37}, LocalScheduler>, LocalScheduler>>, {closure@tests/v1_integration.rs:141:15: 141:18}>>, LocalScheduler>: rxrust::Observable`
    = note: the full name for the type has been written to '/home/mightyiam/worktrees/rxRust/target/debug/deps/v1_integration-d0cdfb155180072f.long-type-15924575575005512438.txt'
    = note: consider using `--verbose` to print the full type name to the console

For more information about this error, try `rustc --explain E0599`.
error: could not compile `rxrust` (test "v1_integration") due to 1 previous error
```