### PR TITLE
fix(ops):🐛 delayed operator subscription closed semantics

### DIFF
--- a/src/ops/buffer_time.rs
+++ b/src/ops/buffer_time.rs
@@ -292,4 +292,27 @@ mod tests {
     // Buffer should be emitted due to time
     assert_eq!(*result.borrow(), vec![vec![1, 2]]);
   }
+
+  #[rxrust_macro::test]
+  fn test_buffer_time_subscription_closes_immediately_on_sync_complete() {
+    use crate::{
+      context::TestCtx, scheduler::test_scheduler::TestScheduler, subscription::Subscription,
+    };
+
+    TestScheduler::init();
+
+    let result = Rc::new(RefCell::new(Vec::new()));
+    let result_clone = result.clone();
+    let completed = Rc::new(RefCell::new(false));
+    let completed_c = completed.clone();
+
+    let subscription = TestCtx::of(42)
+      .buffer_time(Duration::from_millis(100))
+      .on_complete(move || *completed_c.borrow_mut() = true)
+      .subscribe(move |v: Vec<i32>| result_clone.borrow_mut().push(v));
+
+    assert_eq!(*result.borrow(), vec![vec![42]]);
+    assert!(*completed.borrow());
+    assert!(subscription.is_closed());
+  }
 }

--- a/src/ops/debounce.rs
+++ b/src/ops/debounce.rs
@@ -320,4 +320,27 @@ mod tests {
     assert_eq!(result.len(), 1);
     assert!(*completed.lock().unwrap());
   }
+
+  #[rxrust_macro::test]
+  fn test_debounce_subscription_closes_immediately_on_sync_complete() {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::{context::TestCtx, prelude::TestScheduler, subscription::Subscription};
+
+    TestScheduler::init();
+
+    let values = Rc::new(RefCell::new(Vec::new()));
+    let values_c = values.clone();
+    let completed = Rc::new(RefCell::new(false));
+    let completed_c = completed.clone();
+
+    let subscription = TestCtx::of(42)
+      .debounce(Duration::from_millis(100))
+      .on_complete(move || *completed_c.borrow_mut() = true)
+      .subscribe(move |v| values_c.borrow_mut().push(v));
+
+    assert_eq!(*values.borrow(), vec![42]);
+    assert!(*completed.borrow());
+    assert!(subscription.is_closed());
+  }
 }

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -99,8 +99,8 @@ where
 {
   let (observer, state, id) = task_state;
 
-  state.rc_deref_mut().remove(*id);
   observer.clone().complete();
+  state.rc_deref_mut().remove(*id);
 
   TaskState::Finished
 }
@@ -439,6 +439,78 @@ mod tests {
     let elapsed = start.elapsed();
     assert_eq!(*values.lock().unwrap(), vec![1]);
     assert!(elapsed >= Duration::from_millis(40));
+  }
+
+  #[rxrust_macro::test]
+  fn test_delay_subscription_stays_open_until_delayed_complete() {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::{context::TestCtx, prelude::TestScheduler, subscription::Subscription};
+
+    TestScheduler::init();
+
+    let values = Rc::new(RefCell::new(Vec::new()));
+    let values_c = values.clone();
+    let completed = Rc::new(RefCell::new(false));
+    let completed_c = completed.clone();
+
+    let subscription = TestCtx::of(42)
+      .delay(Duration::from_millis(100))
+      .on_complete(move || *completed_c.borrow_mut() = true)
+      .subscribe(move |v| values_c.borrow_mut().push(v));
+
+    assert!(!subscription.is_closed());
+    assert!(values.borrow().is_empty());
+    assert!(!*completed.borrow());
+
+    TestScheduler::advance_by(Duration::from_millis(120));
+
+    assert_eq!(*values.borrow(), vec![42]);
+    assert!(*completed.borrow());
+    assert!(subscription.is_closed());
+  }
+
+  #[rxrust_macro::test]
+  fn test_delay_complete_callback_sees_open_subscription_until_delivery_finishes() {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::{
+      context::TestCtx,
+      prelude::TestScheduler,
+      subscription::{BoxedSubscription, IntoBoxedSubscription, Subscription},
+    };
+
+    TestScheduler::init();
+
+    let subscription_cell = Rc::new(RefCell::new(None::<BoxedSubscription>));
+    let subscription_cell_c = subscription_cell.clone();
+    let closed_during_complete = Rc::new(RefCell::new(None));
+    let closed_during_complete_c = closed_during_complete.clone();
+
+    let subscription = TestCtx::of(42)
+      .delay(Duration::from_millis(100))
+      .on_complete(move || {
+        let is_closed = subscription_cell_c
+          .borrow()
+          .as_ref()
+          .expect("subscription should be assigned before delayed complete runs")
+          .is_closed();
+        *closed_during_complete_c.borrow_mut() = Some(is_closed);
+      })
+      .subscribe(|_| {});
+
+    *subscription_cell.borrow_mut() = Some(subscription.into_boxed());
+
+    TestScheduler::advance_by(Duration::from_millis(120));
+
+    assert_eq!(*closed_during_complete.borrow(), Some(false));
+    assert!(
+      subscription_cell
+        .borrow()
+        .as_ref()
+        .expect("subscription should still be stored after completion")
+        .is_closed()
+    );
   }
 
   /// Test that delay cancellation prevents emission.

--- a/src/ops/merge_all.rs
+++ b/src/ops/merge_all.rs
@@ -341,6 +341,35 @@ mod tests {
     assert!(*completed.borrow());
   }
 
+  #[rxrust_macro::test(local)]
+  async fn test_merge_all_subscription_stays_open_while_inner_active() {
+    use std::time::Duration;
+
+    use crate::{scheduler::LocalScheduler, subscription::Subscription};
+
+    let values = Rc::new(RefCell::new(Vec::new()));
+    let values_c = values.clone();
+    let completed = Rc::new(RefCell::new(false));
+    let completed_c = completed.clone();
+
+    let subscription = Local::of(Local::of(42).delay_subscription(Duration::from_millis(20)))
+      .merge_all(usize::MAX)
+      .on_complete(move || *completed_c.borrow_mut() = true)
+      .subscribe(move |v| values_c.borrow_mut().push(v));
+
+    assert!(!subscription.is_closed());
+    assert!(values.borrow().is_empty());
+    assert!(!*completed.borrow());
+
+    LocalScheduler
+      .sleep(Duration::from_millis(40))
+      .await;
+
+    assert_eq!(*values.borrow(), vec![42]);
+    assert!(*completed.borrow());
+    assert!(subscription.is_closed());
+  }
+
   #[rxrust_macro::test]
   fn test_merge_all_concurrency() {
     let result = Rc::new(RefCell::new(Vec::new()));

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -291,4 +291,31 @@ mod tests {
     let vals = values.lock().unwrap();
     assert!(vals.is_empty(), "Received {:?} but expected empty", vals);
   }
+
+  #[rxrust_macro::test(local)]
+  async fn test_observe_on_subscription_stays_open_until_scheduled_complete() {
+    use crate::subscription::Subscription;
+
+    let values = Arc::new(Mutex::new(Vec::new()));
+    let values_c = values.clone();
+    let completed = Arc::new(Mutex::new(false));
+    let completed_c = completed.clone();
+
+    let subscription = Local::of(42)
+      .observe_on(LocalScheduler)
+      .on_complete(move || *completed_c.lock().unwrap() = true)
+      .subscribe(move |v| values_c.lock().unwrap().push(v));
+
+    assert!(!subscription.is_closed());
+    assert!(values.lock().unwrap().is_empty());
+    assert!(!*completed.lock().unwrap());
+
+    LocalScheduler
+      .sleep(Duration::from_millis(0))
+      .await;
+
+    assert_eq!(*values.lock().unwrap(), vec![42]);
+    assert!(*completed.lock().unwrap());
+    assert!(subscription.is_closed());
+  }
 }

--- a/src/ops/throttle.rs
+++ b/src/ops/throttle.rs
@@ -18,7 +18,7 @@ use crate::{
   observable::{CoreObservable, ObservableType},
   observer::Observer,
   scheduler::Duration,
-  subscription::{IntoBoxedSubscription, SourceWithHandle, Subscription},
+  subscription::{IntoBoxedSubscription, Subscription},
 };
 
 // ===== ThrottleEdge =====·
@@ -111,7 +111,28 @@ where
 // ===== Subscription/state =====
 
 /// Subscription for the throttle operator.
-pub type ThrottleSubscription<U, H> = SourceWithHandle<U, H>;
+pub struct ThrottleSubscription<U, H> {
+  source: U,
+  handle: H,
+}
+
+impl<U, H> ThrottleSubscription<U, H> {
+  #[inline]
+  fn new(source: U, handle: H) -> Self { Self { source, handle } }
+}
+
+impl<U, H> Subscription for ThrottleSubscription<U, H>
+where
+  U: Subscription,
+  H: Subscription,
+{
+  fn unsubscribe(self) {
+    self.handle.unsubscribe();
+    self.source.unsubscribe();
+  }
+
+  fn is_closed(&self) -> bool { self.handle.is_closed() }
+}
 
 pub struct ThrottleState<Item, O, Param, BoxedSub> {
   // Downstream observer.
@@ -229,17 +250,18 @@ where
           observer.next(pending);
         }
       }
-      (pending, completed) => {
-        // If we don't need to start the next window, we can flush/complete while
-        // holding the guard.
+      (pending, true) => {
         if let (Some(p), Some(observer)) = (pending, inner.observer.as_mut()) {
           observer.next(p);
         }
 
-        if completed && let Some(observer) = inner.observer.take() {
+        if let Some(observer) = inner.observer.take() {
           observer.complete();
         }
+
+        *guard = None;
       }
+      (None, false) => {}
     }
   }
 
@@ -320,6 +342,8 @@ where
     if let Some(observer) = state.observer.take() {
       observer.complete();
     }
+
+    *guard = None;
   }
 
   fn is_closed(&self) -> bool {
@@ -418,7 +442,7 @@ where
     });
 
     let source_unsub = source.subscribe(wrapped);
-    SourceWithHandle::new(source_unsub, state_handle)
+    ThrottleSubscription::new(source_unsub, state_handle)
   }
 }
 
@@ -543,6 +567,38 @@ mod tests {
     // Window end should emit trailing value, then complete.
     assert_eq!(result, vec![42]);
     assert!(*completed.borrow());
+  }
+
+  #[rxrust_macro::test]
+  async fn test_throttle_trailing_subscription_stays_open_until_delayed_flush() {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::{context::TestCtx, prelude::TestScheduler, subscription::Subscription};
+
+    TestScheduler::init();
+    let values = Rc::new(RefCell::new(Vec::new()));
+    let values_c = values.clone();
+    let completed = Rc::new(RefCell::new(false));
+    let completed_c = completed.clone();
+
+    let subscription = TestCtx::of(42)
+      .throttle_time(Duration::from_millis(100), ThrottleEdge::trailing())
+      .on_complete(move || *completed_c.borrow_mut() = true)
+      .subscribe(move |v| values_c.borrow_mut().push(v));
+
+    TestScheduler::advance_by(Duration::from_millis(10));
+    assert!(
+      !subscription.is_closed(),
+      "trailing throttle must stay open while the delayed trailing value is pending"
+    );
+    assert!(values.borrow().is_empty());
+    assert!(!*completed.borrow());
+
+    TestScheduler::advance_by(Duration::from_millis(120));
+
+    assert_eq!(*values.borrow(), vec![42]);
+    assert!(*completed.borrow());
+    assert!(subscription.is_closed());
   }
 
   #[rxrust_macro::test]

--- a/src/subscription/source_with_dynamic.rs
+++ b/src/subscription/source_with_dynamic.rs
@@ -48,5 +48,5 @@ where
     self.subs.rc_deref_mut().unsubscribe_all();
   }
 
-  fn is_closed(&self) -> bool { self.source.is_closed() }
+  fn is_closed(&self) -> bool { self.source.is_closed() && self.subs.rc_deref().all_closed() }
 }


### PR DESCRIPTION
    Ensure subscriptions stay open until delayed work is actually delivered.