### PR TITLE
switch_map followed by box_it fails to satisfy `CoreObservable`

### DIFF
--- a/src/ops/switch_map.rs
+++ b/src/ops/switch_map.rs
@@ -32,6 +32,8 @@
 //! source.next(2);
 //! ```
 
+use std::marker::PhantomData;
+
 use crate::{
   context::{Context, RcDeref, RcDerefMut, Scope},
   observable::{CoreObservable, ObservableType},
@@ -85,9 +87,10 @@ where
 
 #[doc(hidden)]
 #[derive(Clone)]
-pub struct SwitchMapOuterObserver<Sc: Scope, O, F> {
+pub struct SwitchMapOuterObserver<Sc: Scope, O, F, InnerObs> {
   state: SwitchState<Sc, O>,
   func: F,
+  _inner: PhantomData<fn() -> InnerObs>,
 }
 
 #[doc(hidden)]
@@ -151,7 +154,7 @@ type InnerObserverCtx<C> = <C as Context>::With<
 impl<S, F, C, Out, InnerObs> CoreObservable<C> for SwitchMap<S, F>
 where
   C: Context,
-  S: CoreObservable<C::With<SwitchMapOuterObserver<C::Scope, C::Inner, F>>>,
+  S: CoreObservable<C::With<SwitchMapOuterObserver<C::Scope, C::Inner, F, InnerObs>>>,
   F: for<'a> FnMut(S::Item<'a>) -> Out,
   Out: Context<Inner = InnerObs>,
   InnerObs: CoreObservable<InnerObserverCtx<C>, Err = S::Err> + 'static,
@@ -167,7 +170,7 @@ where
     let wrapped = context.transform(|observer| {
       *state.rc_deref_mut() =
         Some(SwitchMapState { observer, outer_completed: false, inner_sub: None });
-      SwitchMapOuterObserver { state: state.clone(), func }
+      SwitchMapOuterObserver { state: state.clone(), func, _inner: PhantomData }
     });
 
     let source_unsub = source.subscribe(wrapped);
@@ -176,7 +179,8 @@ where
   }
 }
 
-impl<Sc, O, InnerObs, Item, Err, F, Out> Observer<Item, Err> for SwitchMapOuterObserver<Sc, O, F>
+impl<Sc, O, InnerObs, Item, Err, F, Out> Observer<Item, Err>
+  for SwitchMapOuterObserver<Sc, O, F, InnerObs>
 where
   Sc: Scope,
   O: for<'a> Observer<InnerObs::Item<'a>, Err>,

--- a/tests/v1_integration.rs
+++ b/tests/v1_integration.rs
@@ -14,7 +14,9 @@ use rxrust::{
   scheduler::{Duration, LocalScheduler, SleepProvider},
 };
 
-fn approx_eq(expected: f64, actual: f64) -> bool { (expected - actual).abs() <= 1e-9 }
+fn approx_eq(expected: f64, actual: f64) -> bool {
+  (expected - actual).abs() <= 1e-9
+}
 
 #[rxrust_macro::test]
 fn test_basic_chain_integration() {
@@ -29,6 +31,39 @@ fn test_basic_chain_integration() {
     .subscribe(move |v| result_clone.borrow_mut().push(v));
 
   assert_eq!(*result.borrow(), vec![12, 14, 16]);
+}
+
+#[rxrust_macro::test]
+fn test_switch_map_box_it() {
+  // No problem with these
+  Shared::empty().box_it();
+  Shared::empty().switch_map(|s| Shared::of(""));
+  Shared::empty()
+    .flat_map(|s| Shared::empty())
+    .box_it();
+  Shared::of(true)
+    .switch_map(|s| Shared::of(true))
+    .subscribe(|_| {});
+
+  // All these variations fail to satisfy trait bounds
+  Shared::of(true)
+    .switch_map(|s| Shared::of(true))
+    .box_it();
+  Shared::empty()
+    .switch_map(|s| Shared::empty())
+    .box_it();
+  Shared::empty()
+    .switch_map(|s| Shared::of(true))
+    .box_it();
+  Shared::empty()
+    .switch_map(|s| Shared::of(""))
+    .box_it();
+  Shared::of(true)
+    .switch_map(|s| Shared::of(true))
+    .box_it_clone();
+  Local::empty()
+    .switch_map(|s| Local::empty())
+    .box_it();
 }
 
 #[rxrust_macro::test]

--- a/tests/v1_integration.rs
+++ b/tests/v1_integration.rs
@@ -14,9 +14,7 @@ use rxrust::{
   scheduler::{Duration, LocalScheduler, SleepProvider},
 };
 
-fn approx_eq(expected: f64, actual: f64) -> bool {
-  (expected - actual).abs() <= 1e-9
-}
+fn approx_eq(expected: f64, actual: f64) -> bool { (expected - actual).abs() <= 1e-9 }
 
 #[rxrust_macro::test]
 fn test_basic_chain_integration() {
@@ -37,32 +35,32 @@ fn test_basic_chain_integration() {
 fn test_switch_map_box_it() {
   // No problem with these
   Shared::empty().box_it();
-  Shared::empty().switch_map(|s| Shared::of(""));
+  Shared::empty().switch_map(|_| Shared::of(""));
   Shared::empty()
-    .flat_map(|s| Shared::empty())
+    .flat_map(|_| Shared::empty())
     .box_it();
   Shared::of(true)
-    .switch_map(|s| Shared::of(true))
+    .switch_map(|_| Shared::of(true))
     .subscribe(|_| {});
 
   // All these variations fail to satisfy trait bounds
   Shared::of(true)
-    .switch_map(|s| Shared::of(true))
+    .switch_map(|_| Shared::of(true))
     .box_it();
   Shared::empty()
-    .switch_map(|s| Shared::empty())
+    .switch_map(|_| Shared::empty())
     .box_it();
   Shared::empty()
-    .switch_map(|s| Shared::of(true))
+    .switch_map(|_| Shared::of(true))
     .box_it();
   Shared::empty()
-    .switch_map(|s| Shared::of(""))
+    .switch_map(|_| Shared::of(""))
     .box_it();
   Shared::of(true)
-    .switch_map(|s| Shared::of(true))
+    .switch_map(|_| Shared::of(true))
     .box_it_clone();
   Local::empty()
-    .switch_map(|s| Local::empty())
+    .switch_map(|_| Local::empty())
     .box_it();
 }
 


### PR DESCRIPTION
Hey, this is not a concrete contribution, but an issue reproduction.
I don't suppose you need me to open a corresponding issue, right?
Anyway, @shivaraj-bh and I tried to think how we may be holding it wrong and couldn't.
We added a control group to check our sanity. And variations on what we actually originally hit.
Then we compared between the `FlatMap` and `SwitchMap` types and what caught our eye is the sheer
size of the `SwitchMap` `CoreObservable` implementation. I remarked "oh, wow. I wouldn't be surprised if an issue was overlooked there".
Anyway, I hope this report is actually useful and suffices for you experts to identify the issue or let us know how we're holding it wrong.
Thank you.
