### PR TITLE
chore: rm scheduler field from Retry

### DIFF
--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1220,12 +1220,11 @@ pub trait Observable: Context {
   ///   .on_error(|_e| {})
   ///   .subscribe(|_| {});
   /// ```
-  fn retry<P>(self, policy: P) -> Self::With<Retry<Self::Inner, P, Self::Scheduler>>
+  fn retry<P>(self, policy: P) -> Self::With<Retry<Self::Inner, P>>
   where
     P: RetryPolicy<Self::Err>,
   {
-    let scheduler = self.scheduler().clone();
-    self.transform(|source| Retry { source, policy, scheduler })
+    self.transform(|source| Retry { source, policy })
   }
 
   /// Throttle emissions by ignoring values during a window

--- a/src/ops/retry.rs
+++ b/src/ops/retry.rs
@@ -256,10 +256,9 @@ impl<Err> RetryPolicy<Err> for RetryConfig {
 
 /// The Retry operator struct.
 #[derive(Clone)]
-pub struct Retry<S, P, Sch> {
+pub struct Retry<S, P> {
   pub source: S,
   pub policy: P,
-  pub scheduler: Sch,
 }
 
 /// Observer for retry operator.
@@ -283,7 +282,7 @@ where
   subscribe_fn: fn(Self),
 }
 
-impl<S, P, Sch> ObservableType for Retry<S, P, Sch>
+impl<S, P> ObservableType for Retry<S, P>
 where
   S: ObservableType,
 {
@@ -306,7 +305,7 @@ where
   type Err = S::Err;
 }
 
-impl<S, P, Sch, Ctx> CoreObservable<Ctx> for Retry<S, P, Sch>
+impl<S, P, Ctx> CoreObservable<Ctx> for Retry<S, P>
 where
   Ctx: Context,
   S: CoreObservable<Ctx::With<RetryObserver<S, P, Ctx>>> + Clone,


### PR DESCRIPTION
Hey, while studying towards `catch_error` we noticed that this field can be removed and `cargo test` still passes.

We understand that a scheduler performs effects. Scheduling tasks.
So we kind of expect you to tell us that yes, it needs to be kept alive within this field and that this success is a race condition.
We also noticed such fields in `Delay` and `Debounce`, which makes sense.
But if that's the case, can these fields have test coverage?
